### PR TITLE
changed signal handling thread from detached to joinable

### DIFF
--- a/targets/server-linux/SlideRule.cpp
+++ b/targets/server-linux/SlideRule.cpp
@@ -291,7 +291,6 @@ int main (int argc, char* argv[])
     pthread_t signal_pid;
     pthread_attr_t pthread_attr;
     pthread_attr_init(&pthread_attr);
-    pthread_attr_setdetachstate(&pthread_attr, PTHREAD_CREATE_DETACHED);
     pthread_create(&signal_pid, &pthread_attr, &signal_thread, reinterpret_cast<void*>(&signal_set));
 
     /* Initialize Built-In Packages */


### PR DESCRIPTION
Attempting to join a detached thread is undefined behavior. With the latest dev tools the AddressSanitizer would abort and prevented the detection of memory leaks. Making the signal-handling thread joinable ensures proper synchronization allowing AddressSanitizer to function correctly and detect any potential memory leaks.