### PR TITLE
h5coro allrows (-1) fix for icesat2 and gedi readers

### DIFF
--- a/plugins/gedi/plugin/FootprintReader.h
+++ b/plugins/gedi/plugin/FootprintReader.h
@@ -326,7 +326,7 @@ FootprintReader<footprint_t>::Region::Region (const info_t* info):
     }
     else
     {
-        num_footprints = MIN(lat.size, lon.size);
+        num_footprints = lat.size;
     }
 
     /* Check If Anything to Process */

--- a/plugins/gedi/plugin/FootprintReader.h
+++ b/plugins/gedi/plugin/FootprintReader.h
@@ -320,7 +320,7 @@ FootprintReader<footprint_t>::Region::Region (info_t* info):
     {
         rasterregion(info);
     }
-    else if(info->reader->parms->polygon.length() > 0)
+    else if(!info->reader->parms->polygon.empty())
     {
         polyregion(info);
     }

--- a/plugins/gedi/plugin/FootprintReader.h
+++ b/plugins/gedi/plugin/FootprintReader.h
@@ -100,12 +100,12 @@ class FootprintReader: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     lat;
                 H5Array<double>     lon;
@@ -301,7 +301,7 @@ FootprintReader<footprint_t>::~FootprintReader (void)
  * Region::Constructor
  *----------------------------------------------------------------------------*/
 template <class footprint_t>
-FootprintReader<footprint_t>::Region::Region (info_t* info):
+FootprintReader<footprint_t>::Region::Region (const info_t* info):
     lat             (info->reader->asset, info->reader->resource, FString("%s/%s", GediParms::beam2group(info->beam), info->reader->latName).c_str(), &info->reader->context),
     lon             (info->reader->asset, info->reader->resource, FString("%s/%s", GediParms::beam2group(info->beam), info->reader->lonName).c_str(), &info->reader->context),
     inclusion_mask  (NULL),
@@ -363,7 +363,7 @@ void FootprintReader<footprint_t>::Region::cleanup (void)
  * Region::polyregion
  *----------------------------------------------------------------------------*/
 template <class footprint_t>
-void FootprintReader<footprint_t>::Region::polyregion (info_t* info)
+void FootprintReader<footprint_t>::Region::polyregion (const info_t* info)
 {
     /* Find First and Last Footprints in Polygon */
     bool first_footprint_found = false;
@@ -409,7 +409,7 @@ void FootprintReader<footprint_t>::Region::polyregion (info_t* info)
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
 template <class footprint_t>
-void FootprintReader<footprint_t>::Region::rasterregion (info_t* info)
+void FootprintReader<footprint_t>::Region::rasterregion (const info_t* info)
 {
     /* Allocate Inclusion Mask */
     if(lat.size <= 0) return;

--- a/plugins/gedi/plugin/Gedi01bReader.cpp
+++ b/plugins/gedi/plugin/Gedi01bReader.cpp
@@ -181,24 +181,21 @@ void* Gedi01bReader::subsettingThread (void* parm)
         /* Read GEDI Datasets */
         const Gedi01b gedi01b(info, region);
 
-        /* Get Number of Footprints */
-        const long num_footprints = region.num_footprints != H5Coro::ALL_ROWS ? region.num_footprints : gedi01b.delta_time.size;
-
         /* Read Waveforms */
         const long tx0 = gedi01b.tx_start_index[0] - 1;
-        const long txN = gedi01b.tx_start_index[num_footprints - 1] - 1 + gedi01b.tx_sample_count[num_footprints - 1] - tx0;
+        const long txN = gedi01b.tx_start_index[region.num_footprints - 1] - 1 + gedi01b.tx_sample_count[region.num_footprints - 1] - tx0;
         const long rx0 = gedi01b.rx_start_index[0] - 1;
-        const long rxN = gedi01b.rx_start_index[num_footprints - 1] - 1 + gedi01b.rx_sample_count[num_footprints - 1] - rx0;
+        const long rxN = gedi01b.rx_start_index[region.num_footprints - 1] - 1 + gedi01b.rx_sample_count[region.num_footprints - 1] - rx0;
         H5Array<float> txwaveform(info->reader->asset, info->reader->resource, FString("%s/txwaveform", GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, tx0, txN);
         H5Array<float> rxwaveform(info->reader->asset, info->reader->resource, FString("%s/rxwaveform", GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, rx0, rxN);
         txwaveform.join(info->reader->read_timeout_ms, true);
         rxwaveform.join(info->reader->read_timeout_ms, true);
 
         /* Increment Read Statistics */
-        local_stats.footprints_read = num_footprints;
+        local_stats.footprints_read = region.num_footprints;
 
         /* Traverse All Footprints In Dataset */
-        for(long footprint = 0; reader->active && footprint < num_footprints; footprint++)
+        for(long footprint = 0; reader->active && footprint < region.num_footprints; footprint++)
         {
             /* Check Degrade Filter */
             if(parms->degrade_filter != GediParms::DEGRADE_UNFILTERED)

--- a/plugins/gedi/plugin/Gedi01bReader.cpp
+++ b/plugins/gedi/plugin/Gedi01bReader.cpp
@@ -128,7 +128,7 @@ Gedi01bReader::~Gedi01bReader (void) = default;
 /*----------------------------------------------------------------------------
  * Gedi01b::Constructor
  *----------------------------------------------------------------------------*/
-Gedi01bReader::Gedi01b::Gedi01b (info_t* info, Region& region):
+Gedi01bReader::Gedi01b::Gedi01b (const info_t* info, const Region& region):
     shot_number     (info->reader->asset, info->reader->resource, FString("%s/shot_number",                  GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     delta_time      (info->reader->asset, info->reader->resource, FString("%s/geolocation/delta_time",       GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     elev_bin0       (info->reader->asset, info->reader->resource, FString("%s/geolocation/elevation_bin0",   GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
@@ -164,7 +164,7 @@ Gedi01bReader::Gedi01b::~Gedi01b (void) = default;
 void* Gedi01bReader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Gedi01bReader* reader = reinterpret_cast<Gedi01bReader*>(info->reader);
     const GediParms* parms = reader->parms;
     stats_t local_stats = {0, 0, 0, 0, 0};
@@ -176,7 +176,7 @@ void* Gedi01bReader::subsettingThread (void* parm)
     try
     {
         /* Subset to Region of Interest */
-        Region region(info);
+        const Region region(info);
 
         /* Read GEDI Datasets */
         const Gedi01b gedi01b(info, region);

--- a/plugins/gedi/plugin/Gedi01bReader.h
+++ b/plugins/gedi/plugin/Gedi01bReader.h
@@ -106,7 +106,7 @@ class Gedi01bReader: public FootprintReader<g01b_footprint_t>
         {
             public:
 
-                Gedi01b             (info_t* info, Region& region);
+                Gedi01b             (const info_t* info, const Region& region);
                 ~Gedi01b            (void);
 
                 H5Array<uint64_t>   shot_number;

--- a/plugins/gedi/plugin/Gedi02aReader.cpp
+++ b/plugins/gedi/plugin/Gedi02aReader.cpp
@@ -125,7 +125,7 @@ Gedi02aReader::~Gedi02aReader (void) = default;
 /*----------------------------------------------------------------------------
  * Gedi02a::Constructor
  *----------------------------------------------------------------------------*/
-Gedi02aReader::Gedi02a::Gedi02a (info_t* info, Region& region):
+Gedi02aReader::Gedi02a::Gedi02a (const info_t* info, const Region& region):
     shot_number     (info->reader->asset, info->reader->resource, FString("%s/shot_number",      GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     delta_time      (info->reader->asset, info->reader->resource, FString("%s/delta_time",       GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     elev_lowestmode (info->reader->asset, info->reader->resource, FString("%s/elev_lowestmode",  GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
@@ -160,7 +160,7 @@ Gedi02aReader::Gedi02a::~Gedi02a (void) = default;
 void* Gedi02aReader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Gedi02aReader* reader = reinterpret_cast<Gedi02aReader*>(info->reader); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
     const GediParms* parms = reader->parms;
     stats_t local_stats = {0, 0, 0, 0, 0};
@@ -172,7 +172,7 @@ void* Gedi02aReader::subsettingThread (void* parm)
     try
     {
         /* Subset to Region of Interest */
-        Region region(info);
+        const Region region(info);
 
         /* Read GEDI Datasets */
         const Gedi02a gedi02a(info, region);

--- a/plugins/gedi/plugin/Gedi02aReader.cpp
+++ b/plugins/gedi/plugin/Gedi02aReader.cpp
@@ -175,18 +175,21 @@ void* Gedi02aReader::subsettingThread (void* parm)
         Region region(info);
 
         /* Read GEDI Datasets */
-        const Gedi02a Gedi02a(info, region);
+        const Gedi02a gedi02a(info, region);
+
+        /* Get Number of Footprints */
+        const long num_footprints = region.num_footprints != H5Coro::ALL_ROWS ? region.num_footprints : gedi02a.delta_time.size;
 
         /* Increment Read Statistics */
-        local_stats.footprints_read = region.num_footprints;
+        local_stats.footprints_read = num_footprints;
 
         /* Traverse All Footprints In Dataset */
-        for(long footprint = 0; reader->active && footprint < region.num_footprints; footprint++)
+        for(long footprint = 0; reader->active && footprint < num_footprints; footprint++)
         {
             /* Check Degrade Filter */
             if(parms->degrade_filter != GediParms::DEGRADE_UNFILTERED)
             {
-                if(Gedi02a.degrade_flag[footprint] != parms->degrade_filter)
+                if(gedi02a.degrade_flag[footprint] != parms->degrade_filter)
                 {
                     local_stats.footprints_filtered++;
                     continue;
@@ -196,7 +199,7 @@ void* Gedi02aReader::subsettingThread (void* parm)
             /* Check L2 Quality Filter */
             if(parms->l2_quality_filter != GediParms::L2QLTY_UNFILTERED)
             {
-                if(Gedi02a.quality_flag[footprint] != parms->l2_quality_filter)
+                if(gedi02a.quality_flag[footprint] != parms->l2_quality_filter)
                 {
                     local_stats.footprints_filtered++;
                     continue;
@@ -206,7 +209,7 @@ void* Gedi02aReader::subsettingThread (void* parm)
             /* Check Surface Filter */
             if(parms->surface_filter != GediParms::SURFACE_UNFILTERED)
             {
-                if(Gedi02a.surface_flag[footprint] != parms->surface_filter)
+                if(gedi02a.surface_flag[footprint] != parms->surface_filter)
                 {
                     local_stats.footprints_filtered++;
                     continue;
@@ -226,19 +229,19 @@ void* Gedi02aReader::subsettingThread (void* parm)
             {
                 /* Populate Entry in Batch Structure */
                 g02a_footprint_t* fp = &reader->batchData->footprint[reader->batchIndex];
-                fp->shot_number             = Gedi02a.shot_number[footprint];
-                fp->time_ns                 = GediParms::deltatime2timestamp(Gedi02a.delta_time[footprint]);
+                fp->shot_number             = gedi02a.shot_number[footprint];
+                fp->time_ns                 = GediParms::deltatime2timestamp(gedi02a.delta_time[footprint]);
                 fp->latitude                = region.lat[footprint];
                 fp->longitude               = region.lon[footprint];
-                fp->elevation_lowestmode    = Gedi02a.elev_lowestmode[footprint];
-                fp->elevation_highestreturn = Gedi02a.elev_highestreturn[footprint];
-                fp->solar_elevation         = Gedi02a.solar_elevation[footprint];
-                fp->sensitivity             = Gedi02a.sensitivity[footprint];
+                fp->elevation_lowestmode    = gedi02a.elev_lowestmode[footprint];
+                fp->elevation_highestreturn = gedi02a.elev_highestreturn[footprint];
+                fp->solar_elevation         = gedi02a.solar_elevation[footprint];
+                fp->sensitivity             = gedi02a.sensitivity[footprint];
                 fp->beam                    = info->beam;
                 fp->flags                   = 0;
-                if(Gedi02a.degrade_flag[footprint]) fp->flags |= GediParms::DEGRADE_FLAG_MASK;
-                if(Gedi02a.quality_flag[footprint]) fp->flags |= GediParms::L2_QUALITY_FLAG_MASK;
-                if(Gedi02a.surface_flag[footprint]) fp->flags |= GediParms::SURFACE_FLAG_MASK;
+                if(gedi02a.degrade_flag[footprint]) fp->flags |= GediParms::DEGRADE_FLAG_MASK;
+                if(gedi02a.quality_flag[footprint]) fp->flags |= GediParms::L2_QUALITY_FLAG_MASK;
+                if(gedi02a.surface_flag[footprint]) fp->flags |= GediParms::SURFACE_FLAG_MASK;
 
                 /* Send Record */
                 reader->batchIndex++;

--- a/plugins/gedi/plugin/Gedi02aReader.cpp
+++ b/plugins/gedi/plugin/Gedi02aReader.cpp
@@ -177,14 +177,11 @@ void* Gedi02aReader::subsettingThread (void* parm)
         /* Read GEDI Datasets */
         const Gedi02a gedi02a(info, region);
 
-        /* Get Number of Footprints */
-        const long num_footprints = region.num_footprints != H5Coro::ALL_ROWS ? region.num_footprints : gedi02a.delta_time.size;
-
         /* Increment Read Statistics */
-        local_stats.footprints_read = num_footprints;
+        local_stats.footprints_read = region.num_footprints;
 
         /* Traverse All Footprints In Dataset */
-        for(long footprint = 0; reader->active && footprint < num_footprints; footprint++)
+        for(long footprint = 0; reader->active && footprint < region.num_footprints; footprint++)
         {
             /* Check Degrade Filter */
             if(parms->degrade_filter != GediParms::DEGRADE_UNFILTERED)

--- a/plugins/gedi/plugin/Gedi02aReader.h
+++ b/plugins/gedi/plugin/Gedi02aReader.h
@@ -101,7 +101,7 @@ class Gedi02aReader: public FootprintReader<g02a_footprint_t>
         {
             public:
 
-                Gedi02a             (info_t* info, Region& region);
+                Gedi02a             (const info_t* info, const Region& region);
                 ~Gedi02a            (void);
 
                 H5Array<uint64_t>   shot_number;

--- a/plugins/gedi/plugin/Gedi04aReader.cpp
+++ b/plugins/gedi/plugin/Gedi04aReader.cpp
@@ -180,11 +180,14 @@ void* Gedi04aReader::subsettingThread (void* parm)
         /* Read GEDI Datasets */
         const Gedi04a gedi04a(info, region);
 
+        /* Get Number of Footprints */
+        const long num_footprints = region.num_footprints != H5Coro::ALL_ROWS ? region.num_footprints : gedi04a.delta_time.size;
+
         /* Increment Read Statistics */
-        local_stats.footprints_read = region.num_footprints;
+        local_stats.footprints_read = num_footprints;
 
         /* Traverse All Footprints In Dataset */
-        for(long footprint = 0; reader->active && footprint < region.num_footprints; footprint++)
+        for(long footprint = 0; reader->active && footprint < num_footprints; footprint++)
         {
             /* Check Degrade Filter */
             if(parms->degrade_filter != GediParms::DEGRADE_UNFILTERED)

--- a/plugins/gedi/plugin/Gedi04aReader.cpp
+++ b/plugins/gedi/plugin/Gedi04aReader.cpp
@@ -180,14 +180,11 @@ void* Gedi04aReader::subsettingThread (void* parm)
         /* Read GEDI Datasets */
         const Gedi04a gedi04a(info, region);
 
-        /* Get Number of Footprints */
-        const long num_footprints = region.num_footprints != H5Coro::ALL_ROWS ? region.num_footprints : gedi04a.delta_time.size;
-
         /* Increment Read Statistics */
-        local_stats.footprints_read = num_footprints;
+        local_stats.footprints_read = region.num_footprints;
 
         /* Traverse All Footprints In Dataset */
-        for(long footprint = 0; reader->active && footprint < num_footprints; footprint++)
+        for(long footprint = 0; reader->active && footprint < region.num_footprints; footprint++)
         {
             /* Check Degrade Filter */
             if(parms->degrade_filter != GediParms::DEGRADE_UNFILTERED)

--- a/plugins/gedi/plugin/Gedi04aReader.cpp
+++ b/plugins/gedi/plugin/Gedi04aReader.cpp
@@ -126,7 +126,7 @@ Gedi04aReader::~Gedi04aReader (void) = default;
 /*----------------------------------------------------------------------------
  * Gedi04a::Constructor
  *----------------------------------------------------------------------------*/
-Gedi04aReader::Gedi04a::Gedi04a (info_t* info, Region& region):
+Gedi04aReader::Gedi04a::Gedi04a (const info_t* info, const Region& region):
     shot_number     (info->reader->asset, info->reader->resource, FString("%s/shot_number",      GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     delta_time      (info->reader->asset, info->reader->resource, FString("%s/delta_time",       GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
     agbd            (info->reader->asset, info->reader->resource, FString("%s/agbd",             GediParms::beam2group(info->beam)).c_str(), &info->reader->context, 0, region.first_footprint, region.num_footprints),
@@ -163,7 +163,7 @@ Gedi04aReader::Gedi04a::~Gedi04a (void) = default;
 void* Gedi04aReader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Gedi04aReader* reader = reinterpret_cast<Gedi04aReader*>(info->reader);
     const GediParms* parms = reader->parms;
     stats_t local_stats = {0, 0, 0, 0, 0};
@@ -175,7 +175,7 @@ void* Gedi04aReader::subsettingThread (void* parm)
     try
     {
         /* Subset to Region of Interest */
-        Region region(info);
+        const Region region(info);
 
         /* Read GEDI Datasets */
         const Gedi04a gedi04a(info, region);

--- a/plugins/gedi/plugin/Gedi04aReader.h
+++ b/plugins/gedi/plugin/Gedi04aReader.h
@@ -101,7 +101,7 @@ class Gedi04aReader: public FootprintReader<g04a_footprint_t>
         {
             public:
 
-                Gedi04a             (info_t* info, Region& region);
+                Gedi04a             (const info_t* info, const Region& region);
                 ~Gedi04a            (void);
 
                 H5Array<uint64_t>   shot_number;

--- a/plugins/icesat2/plugin/Atl03BathyReader.cpp
+++ b/plugins/icesat2/plugin/Atl03BathyReader.cpp
@@ -348,7 +348,15 @@ Atl03BathyReader::Region::Region (info_t* info):
         }
         else
         {
-            return; // early exit since no subsetting required
+            num_segments = segment_ph_cnt.size;
+            if(num_segments > 0)
+            {
+                num_photons = 0;
+                for(int i = 0; i < num_segments; i++)
+                {
+                    num_photons += segment_ph_cnt[i];
+                }
+            }
         }
 
         /* Check If Anything to Process */
@@ -743,7 +751,7 @@ Atl03BathyReader::OrbitInfo::OrbitInfo (const Asset* asset, const char* resource
  * OrbitInfo::tojson
  *----------------------------------------------------------------------------*/
 const char* Atl03BathyReader::OrbitInfo::tojson (void) const
-{    
+{
     FString json_contents(R"({)"
     R"("crossing_time":%lf,)"
     R"("cycle_number":%d,)"

--- a/plugins/icesat2/plugin/Atl03BathyReader.cpp
+++ b/plugins/icesat2/plugin/Atl03BathyReader.cpp
@@ -349,13 +349,10 @@ Atl03BathyReader::Region::Region (const info_t* info):
         else
         {
             num_segments = segment_ph_cnt.size;
-            if(num_segments > 0)
+            num_photons  = 0;
+            for(int i = 0; i < num_segments; i++)
             {
-                num_photons = 0;
-                for(int i = 0; i < num_segments; i++)
-                {
-                    num_photons += segment_ph_cnt[i];
-                }
+                num_photons += segment_ph_cnt[i];
             }
         }
 

--- a/plugins/icesat2/plugin/Atl03BathyReader.cpp
+++ b/plugins/icesat2/plugin/Atl03BathyReader.cpp
@@ -317,7 +317,7 @@ Atl03BathyReader::~Atl03BathyReader (void)
 /*----------------------------------------------------------------------------
  * Region::Constructor
  *----------------------------------------------------------------------------*/
-Atl03BathyReader::Region::Region (info_t* info):
+Atl03BathyReader::Region::Region (const info_t* info):
     segment_lat    (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/reference_photon_lat").c_str(), &info->reader->context),
     segment_lon    (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/reference_photon_lon").c_str(), &info->reader->context),
     segment_ph_cnt (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/segment_ph_cnt").c_str(), &info->reader->context),
@@ -397,7 +397,7 @@ void Atl03BathyReader::Region::cleanup (void)
 /*----------------------------------------------------------------------------
  * Region::polyregion
  *----------------------------------------------------------------------------*/
-void Atl03BathyReader::Region::polyregion (info_t* info)
+void Atl03BathyReader::Region::polyregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -461,7 +461,7 @@ void Atl03BathyReader::Region::polyregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
-void Atl03BathyReader::Region::rasterregion (info_t* info)
+void Atl03BathyReader::Region::rasterregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -544,7 +544,7 @@ void Atl03BathyReader::Region::rasterregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Atl03Data::Constructor
  *----------------------------------------------------------------------------*/
-Atl03BathyReader::Atl03Data::Atl03Data (info_t* info, const Region& region):
+Atl03BathyReader::Atl03Data::Atl03Data (const info_t* info, const Region& region):
     sc_orient           (info->reader->asset, info->reader->resource,                                "/orbit_info/sc_orient",                &info->reader->context),
     velocity_sc         (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/velocity_sc").c_str(),     &info->reader->context, H5Coro::ALL_COLS, region.first_segment, region.num_segments),
     segment_delta_time  (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/delta_time").c_str(),      &info->reader->context, 0, region.first_segment, region.num_segments),
@@ -597,7 +597,7 @@ Atl03BathyReader::Atl03Data::Atl03Data (info_t* info, const Region& region):
 /*----------------------------------------------------------------------------
  * Atl09Class::Constructor
  *----------------------------------------------------------------------------*/
-Atl03BathyReader::Atl09Class::Atl09Class (info_t* info):
+Atl03BathyReader::Atl09Class::Atl09Class (const info_t* info):
     valid       (false),
     met_u10m    (info->reader->missing09 ? NULL : info->reader->asset, info->reader->resource09.c_str(), FString("profile_%d/low_rate/met_u10m", info->track).c_str(), &info->reader->context09),
     met_v10m    (info->reader->missing09 ? NULL : info->reader->asset, info->reader->resource09.c_str(), FString("profile_%d/low_rate/met_v10m", info->track).c_str(), &info->reader->context09),
@@ -778,9 +778,9 @@ const char* Atl03BathyReader::OrbitInfo::tojson (void) const
 void* Atl03BathyReader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Atl03BathyReader* reader = info->reader;
-    BathyParms* parms = reader->parms;
+    const BathyParms* parms = reader->parms;
     RasterObject* ndwiRaster = RasterObject::cppCreate(reader->geoparms);
 
     /* Thread Variables */

--- a/plugins/icesat2/plugin/Atl03BathyReader.h
+++ b/plugins/icesat2/plugin/Atl03BathyReader.h
@@ -130,7 +130,7 @@ class Atl03BathyReader: public LuaObject
             uint8_t         cycle;
             uint8_t         utm_zone;
             uint64_t        extent_id;
-            float           surface_h;              // orthometric (in meters)            
+            float           surface_h;              // orthometric (in meters)
             uint32_t        photon_count;
             photon_t        photons[];              // zero length field
         } extent_t;
@@ -161,12 +161,12 @@ class Atl03BathyReader: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     segment_lat;
                 H5Array<double>     segment_lon;
@@ -186,7 +186,7 @@ class Atl03BathyReader: public LuaObject
         {
             public:
 
-                Atl03Data           (info_t* info, const Region& region);
+                Atl03Data           (const info_t* info, const Region& region);
                 ~Atl03Data          (void) = default;
 
                 /* Read Data */
@@ -220,7 +220,7 @@ class Atl03BathyReader: public LuaObject
         {
             public:
 
-                explicit Atl09Class (info_t* info);
+                explicit Atl09Class (const info_t* info);
                 ~Atl09Class         (void) = default;
 
                 /* Generated Data */
@@ -233,7 +233,7 @@ class Atl03BathyReader: public LuaObject
         };
 
         /* AncillaryData SubClass */
-        class AncillaryData 
+        class AncillaryData
         {
             public:
 
@@ -267,7 +267,7 @@ class Atl03BathyReader: public LuaObject
         };
 
         /* OrbitInfo SubClass */
-        class OrbitInfo 
+        class OrbitInfo
         {
             public:
 

--- a/plugins/icesat2/plugin/Atl03Reader.cpp
+++ b/plugins/icesat2/plugin/Atl03Reader.cpp
@@ -280,7 +280,21 @@ Atl03Reader::Region::Region (info_t* info):
         }
         else
         {
-            return; // early exit since no subsetting required
+#if 0
+            return; // early exit since no subetting required
+#else
+
+            num_segments = segment_ph_cnt.size;
+            if(num_segments > 0)
+            {
+                num_photons = 0;
+                for(int i = 0; i < num_segments; i++)
+                {
+                    num_photons += segment_ph_cnt[i];
+                }
+            }
+            print2term("[%s] No spatial region specified, processing entire dataset, num_segments: %ld, num_photons: %ld\n", info->prefix, num_segments, num_photons);
+#endif
         }
 
         /* Check If Anything to Process */
@@ -299,7 +313,6 @@ Atl03Reader::Region::Region (info_t* info):
         cleanup();
         throw;
     }
-
 }
 
 /*----------------------------------------------------------------------------
@@ -574,7 +587,44 @@ Atl03Reader::Atl03Data::Atl03Data (info_t* info, const Region& region):
             dataset_name = anc_ph_data->next(&array);
         }
     }
+
+    print2term("[%s] Reading %ld segments and %ld photons\n", info->prefix, region.num_segments, region.num_photons);
+    print2term("[%s] Reading %ld segments and %ld photons\n", info->prefix, region.num_segments, dist_ph_along.size);
+
+    print2term("sc_orient:          %s, size: %ld\n", info->prefix, sc_orient.size);
+    print2term("velocity_sc:        %s, size: %ld\n", info->prefix, velocity_sc.size);
+    print2term("segment_delta_time: %s, size: %ld\n", info->prefix, segment_delta_time.size);
+    print2term("segment_id:         %s, size: %ld\n", info->prefix, segment_id.size);
+    print2term("segment_dist_x:     %s, size: %ld\n", info->prefix, segment_dist_x.size);
+    print2term("solar_elevation:    %s, size: %ld\n", info->prefix, solar_elevation.size);
+    print2term("dist_ph_along:      %s, size: %ld\n", info->prefix, dist_ph_along.size);
+    print2term("dist_ph_across:     %s, size: %ld\n", info->prefix, dist_ph_across.size);
+    print2term("h_ph:               %s, size: %ld\n", info->prefix, h_ph.size);
+    print2term("signal_conf_ph:     %s, size: %ld\n", info->prefix, signal_conf_ph.size);
+    print2term("quality_ph:         %s, size: %ld\n", info->prefix, quality_ph.size);
+    print2term("lat_ph:             %s, size: %ld\n", info->prefix, lat_ph.size);
+    print2term("lon_ph:             %s, size: %ld\n", info->prefix, lon_ph.size);
+    print2term("delta_time:         %s, size: %ld\n", info->prefix, delta_time.size);
+    print2term("bckgrd_delta_time:  %s, size: %ld\n", info->prefix, bckgrd_delta_time.size);
+    print2term("bckgrd_rate:        %s, size: %ld\n", info->prefix, bckgrd_rate.size);
+    if (anc_geo_data) {
+        H5DArray* array = NULL;
+        const char* dataset_name = anc_geo_data->first(&array);
+        while (dataset_name != NULL) {
+            print2term("%s:    %s, size: %d\n", dataset_name, info->prefix, array->numElements());
+            dataset_name = anc_geo_data->next(&array);
+        }
+    }
+    if (anc_ph_data) {
+        H5DArray* array = NULL;
+        const char* dataset_name = anc_ph_data->first(&array);
+        while (dataset_name != NULL) {
+            print2term("%s:    %s, size: %d\n", dataset_name, info->prefix, array->numElements());
+            dataset_name = anc_ph_data->next(&array);
+        }
+    }
 }
+
 
 /*----------------------------------------------------------------------------
  * Atl03Data::Destructor
@@ -805,7 +855,8 @@ void Atl03Reader::Atl08Class::classify (const info_t* info, const Region& region
  *----------------------------------------------------------------------------*/
 uint8_t Atl03Reader::Atl08Class::operator[] (int index) const
 {
-    return classification[index];
+    // return classification[index];
+    return classification[index];  // NOLINT(clang-analyzer-core.uninitialized.UndefReturn)
 }
 
 /*----------------------------------------------------------------------------

--- a/plugins/icesat2/plugin/Atl03Reader.cpp
+++ b/plugins/icesat2/plugin/Atl03Reader.cpp
@@ -281,13 +281,10 @@ Atl03Reader::Region::Region (const info_t* info):
         else
         {
             num_segments = segment_ph_cnt.size;
-            if(num_segments > 0)
+            num_photons  = 0;
+            for(int i = 0; i < num_segments; i++)
             {
-                num_photons = 0;
-                for(int i = 0; i < num_segments; i++)
-                {
-                    num_photons += segment_ph_cnt[i];
-                }
+                num_photons += segment_ph_cnt[i];
             }
         }
 

--- a/plugins/icesat2/plugin/Atl03Reader.cpp
+++ b/plugins/icesat2/plugin/Atl03Reader.cpp
@@ -341,6 +341,9 @@ void Atl03Reader::Region::polyregion (info_t* info)
             inclusion = true;
         }
 
+        /* Segments with zero photon count may contain invalid coordinates,
+           making them unsuitable for inclusion in polygon tests. */
+
         /* Check First Segment */
         if(!first_segment_found)
         {

--- a/plugins/icesat2/plugin/Atl03Reader.cpp
+++ b/plugins/icesat2/plugin/Atl03Reader.cpp
@@ -858,10 +858,11 @@ uint8_t Atl03Reader::Atl08Class::operator[] (int index) const
  * YapcScore::Constructor
  *----------------------------------------------------------------------------*/
 Atl03Reader::YapcScore::YapcScore (const info_t* info, const Region& region, const Atl03Data& atl03):
+    enabled {info->reader->parms->stages[Icesat2Parms::STAGE_YAPC]},
     score {NULL}
 {
     /* Do Nothing If Not Enabled */
-    if(!info->reader->parms->stages[Icesat2Parms::STAGE_YAPC])
+    if(!enabled)
     {
         return;
     }

--- a/plugins/icesat2/plugin/Atl03Reader.h
+++ b/plugins/icesat2/plugin/Atl03Reader.h
@@ -150,12 +150,12 @@ class Atl03Reader: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     segment_lat;
                 H5Array<double>     segment_lon;
@@ -175,7 +175,7 @@ class Atl03Reader: public LuaObject
         {
             public:
 
-                Atl03Data           (info_t* info, const Region& region);
+                Atl03Data           (const info_t* info, const Region& region);
                 ~Atl03Data          (void);
 
                 /* Read Data */
@@ -210,7 +210,7 @@ class Atl03Reader: public LuaObject
                 static const uint8_t INVALID_FLAG = 0xFF;
 
                 /* Methods */
-                explicit Atl08Class (const info_t* info);
+                explicit Atl08Class (const info_t* info, const Atl03Data& atl03);
                 ~Atl08Class         (void);
                 void classify       (const info_t* info, const Region& region, const Atl03Data& atl03);
                 uint8_t operator[]  (int index) const;
@@ -219,12 +219,13 @@ class Atl03Reader: public LuaObject
                 bool                enabled;
                 bool                phoreal;
                 bool                ancillary;
+                long                num_photons;
 
                 /* Generated Data */
                 uint8_t*            classification; // [num_photons]
-                float*              relief; // [num_photons]
-                uint8_t*            landcover; // [num_photons]
-                uint8_t*            snowcover; // [num_photons]
+                float*              relief;         // [num_photons]
+                uint8_t*            landcover;      // [num_photons]
+                uint8_t*            snowcover;      // [num_photons]
 
                 /* Read Data */
                 H5Array<int32_t>    atl08_segment_id;
@@ -247,11 +248,11 @@ class Atl03Reader: public LuaObject
         {
             public:
 
-                YapcScore           (info_t* info, const Region& region, const Atl03Data& atl03);
+                YapcScore           (const info_t* info, const Region& region, const Atl03Data& atl03);
                 ~YapcScore          (void);
 
-                void yapcV2         (info_t* info, const Region& region, const Atl03Data& atl03);
-                void yapcV3         (info_t* info, const Region& region, const Atl03Data& atl03);
+                void yapcV2         (const info_t* info, const Region& region, const Atl03Data& atl03);
+                void yapcV3         (const info_t* info, const Region& region, const Atl03Data& atl03);
 
                 uint8_t operator[]  (int index) const;
 

--- a/plugins/icesat2/plugin/Atl03Reader.h
+++ b/plugins/icesat2/plugin/Atl03Reader.h
@@ -210,7 +210,7 @@ class Atl03Reader: public LuaObject
                 static const uint8_t INVALID_FLAG = 0xFF;
 
                 /* Methods */
-                explicit Atl08Class (const info_t* info, const Atl03Data& atl03);
+                explicit Atl08Class (const info_t* info);
                 ~Atl08Class         (void);
                 void classify       (const info_t* info, const Region& region, const Atl03Data& atl03);
                 uint8_t operator[]  (int index) const;
@@ -219,7 +219,6 @@ class Atl03Reader: public LuaObject
                 bool                enabled;
                 bool                phoreal;
                 bool                ancillary;
-                long                num_photons;
 
                 /* Generated Data */
                 uint8_t*            classification; // [num_photons]

--- a/plugins/icesat2/plugin/Atl03Reader.h
+++ b/plugins/icesat2/plugin/Atl03Reader.h
@@ -256,6 +256,9 @@ class Atl03Reader: public LuaObject
 
                 uint8_t operator[]  (int index) const;
 
+                /* Class Data */
+                bool                enabled;
+
                 /* Generated Data */
                 uint8_t*            score; // [num_photons]
         };

--- a/plugins/icesat2/plugin/Atl03Viewer.cpp
+++ b/plugins/icesat2/plugin/Atl03Viewer.cpp
@@ -310,7 +310,7 @@ void Atl03Viewer::Region::polyregion (info_t* info)
         }
 
         /* Segments with zero photon count may contain invalid coordinates,
-          making them unsuitable for inclusion in polygon tests. */
+           making them unsuitable for inclusion in polygon tests. */
 
         /* Check First Segment */
         if(!first_segment_found)

--- a/plugins/icesat2/plugin/Atl03Viewer.cpp
+++ b/plugins/icesat2/plugin/Atl03Viewer.cpp
@@ -249,7 +249,7 @@ Atl03Viewer::Region::Region (info_t* info):
         }
         else
         {
-            return; // early exit since no subsetting required
+            num_segments = segment_ph_cnt.size;
         }
 
         /* Check If Anything to Process */
@@ -441,18 +441,15 @@ void* Atl03Viewer::subsettingThread (void* parm)
         /* Read ATL03 Datasets */
         const Atl03Data atl03(info, region);
 
-        /* Get Number of Segments */
-        const long num_segments = region.num_segments != H5Coro::ALL_ROWS ? region.num_segments : atl03.segment_delta_time.size;
-
         /* Increment Read Statistics */
-        local_stats.segments_read = num_segments;
+        local_stats.segments_read = region.num_segments;
 
         List<segment_t> segments;
 
         const uint32_t max_segments_per_extent = 256;
 
         /* Loop Through Each Segment */
-        for(long s = 0; reader->active && s < num_segments; s++)
+        for(long s = 0; reader->active && s < region.num_segments; s++)
         {
             /* Skip segments with zero photon count */
             if(region.segment_ph_cnt[s] == 0) continue;

--- a/plugins/icesat2/plugin/Atl03Viewer.cpp
+++ b/plugins/icesat2/plugin/Atl03Viewer.cpp
@@ -220,7 +220,7 @@ Atl03Viewer::~Atl03Viewer (void)
 /*----------------------------------------------------------------------------
  * Region::Constructor
  *----------------------------------------------------------------------------*/
-Atl03Viewer::Region::Region (info_t* info):
+Atl03Viewer::Region::Region (const info_t* info):
     segment_lat    (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/reference_photon_lat").c_str(), &info->reader->context),
     segment_lon    (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/reference_photon_lon").c_str(), &info->reader->context),
     segment_ph_cnt (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/segment_ph_cnt").c_str(),       &info->reader->context),
@@ -290,7 +290,7 @@ void Atl03Viewer::Region::cleanup (void)
 /*----------------------------------------------------------------------------
  * Region::polyregion
  *----------------------------------------------------------------------------*/
-void Atl03Viewer::Region::polyregion (info_t* info)
+void Atl03Viewer::Region::polyregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -346,7 +346,7 @@ void Atl03Viewer::Region::polyregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
-void Atl03Viewer::Region::rasterregion (info_t* info)
+void Atl03Viewer::Region::rasterregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -401,7 +401,7 @@ void Atl03Viewer::Region::rasterregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Atl03Data::Constructor
  *----------------------------------------------------------------------------*/
-Atl03Viewer::Atl03Data::Atl03Data (info_t* info, const Region& region):
+Atl03Viewer::Atl03Data::Atl03Data (const info_t* info, const Region& region):
     sc_orient           (info->reader->asset, info->reader->resource,                                "/orbit_info/sc_orient",                     &info->reader->context),
     segment_delta_time  (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/delta_time").c_str(),           &info->reader->context, 0, region.first_segment, region.num_segments),
     segment_id          (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "geolocation/segment_id").c_str(),           &info->reader->context, 0, region.first_segment, region.num_segments),
@@ -425,7 +425,7 @@ Atl03Viewer::Atl03Data::~Atl03Data (void) = default;
 void* Atl03Viewer::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Atl03Viewer* reader = info->reader;
     stats_t local_stats = {0, 0, 0, 0, 0};
 

--- a/plugins/icesat2/plugin/Atl03Viewer.h
+++ b/plugins/icesat2/plugin/Atl03Viewer.h
@@ -134,12 +134,12 @@ class Atl03Viewer: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     segment_lat;
                 H5Array<double>     segment_lon;
@@ -157,7 +157,7 @@ class Atl03Viewer: public LuaObject
         {
             public:
 
-                Atl03Data           (info_t* info, const Region& region);
+                Atl03Data           (const info_t* info, const Region& region);
                 ~Atl03Data          (void);
 
                 /* Read Data */

--- a/plugins/icesat2/plugin/Atl06Reader.cpp
+++ b/plugins/icesat2/plugin/Atl06Reader.cpp
@@ -240,7 +240,7 @@ Atl06Reader::~Atl06Reader (void)
 /*----------------------------------------------------------------------------
  * Region::Constructor
  *----------------------------------------------------------------------------*/
-Atl06Reader::Region::Region (info_t* info):
+Atl06Reader::Region::Region (const info_t* info):
     latitude        (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "land_ice_segments/latitude").c_str(),  &info->reader->context),
     longitude       (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "land_ice_segments/longitude").c_str(), &info->reader->context),
     inclusion_mask  {NULL},
@@ -308,7 +308,7 @@ void Atl06Reader::Region::cleanup (void)
 /*----------------------------------------------------------------------------
  * Region::polyregion
  *----------------------------------------------------------------------------*/
-void Atl06Reader::Region::polyregion (info_t* info)
+void Atl06Reader::Region::polyregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -354,7 +354,7 @@ void Atl06Reader::Region::polyregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
-void Atl06Reader::Region::rasterregion (info_t* info)
+void Atl06Reader::Region::rasterregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -409,7 +409,7 @@ void Atl06Reader::Region::rasterregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Atl06Data::Constructor
  *----------------------------------------------------------------------------*/
-Atl06Reader::Atl06Data::Atl06Data (info_t* info, const Region& region):
+Atl06Reader::Atl06Data::Atl06Data (const info_t* info, const Region& region):
     sc_orient               (info->reader->asset, info->reader->resource,                                "/orbit_info/sc_orient",                                           &info->reader->context),
     delta_time              (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "land_ice_segments/delta_time").c_str(),                           &info->reader->context, 0, region.first_segment, region.num_segments),
     h_li                    (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "land_ice_segments/h_li").c_str(),                                 &info->reader->context, 0, region.first_segment, region.num_segments),
@@ -484,9 +484,9 @@ Atl06Reader::Atl06Data::Atl06Data (info_t* info, const Region& region):
 void* Atl06Reader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Atl06Reader* reader = info->reader;
-    Icesat2Parms* parms = reader->parms;
+    const Icesat2Parms* parms = reader->parms;
     stats_t local_stats = {0, 0, 0, 0, 0};
     vector<RecordObject*> rec_vec;
 

--- a/plugins/icesat2/plugin/Atl06Reader.cpp
+++ b/plugins/icesat2/plugin/Atl06Reader.cpp
@@ -267,7 +267,7 @@ Atl06Reader::Region::Region (const info_t* info):
         }
         else
         {
-            num_segments = MIN(latitude.size, longitude.size);
+            num_segments = latitude.size;
         }
 
         /* Check If Anything to Process */

--- a/plugins/icesat2/plugin/Atl06Reader.cpp
+++ b/plugins/icesat2/plugin/Atl06Reader.cpp
@@ -502,8 +502,11 @@ void* Atl06Reader::subsettingThread (void* parm)
         /* Read ATL06 Datasets */
         const Atl06Data atl06(info, region);
 
+        /* Get Number of Segments */
+        const long num_segments = region.num_segments != H5Coro::ALL_ROWS ? region.num_segments : atl06.delta_time.size;
+
         /* Increment Read Statistics */
-        local_stats.segments_read = region.num_segments;
+        local_stats.segments_read = num_segments;
 
         /* Initialize Loop Variables */
         RecordObject* batch_record = NULL;
@@ -512,7 +515,7 @@ void* Atl06Reader::subsettingThread (void* parm)
         int batch_index = 0;
 
         /* Loop Through Each Segment */
-        for(long segment = 0; reader->active && segment < region.num_segments; segment++)
+        for(long segment = 0; reader->active && segment < num_segments; segment++)
         {
             /* Create Elevation Batch Record */
             if(!batch_record)

--- a/plugins/icesat2/plugin/Atl06Reader.cpp
+++ b/plugins/icesat2/plugin/Atl06Reader.cpp
@@ -267,7 +267,7 @@ Atl06Reader::Region::Region (info_t* info):
         }
         else
         {
-            return; // early exit since no subsetting required
+            num_segments = MIN(latitude.size, longitude.size);
         }
 
         /* Check If Anything to Process */
@@ -502,11 +502,8 @@ void* Atl06Reader::subsettingThread (void* parm)
         /* Read ATL06 Datasets */
         const Atl06Data atl06(info, region);
 
-        /* Get Number of Segments */
-        const long num_segments = region.num_segments != H5Coro::ALL_ROWS ? region.num_segments : atl06.delta_time.size;
-
         /* Increment Read Statistics */
-        local_stats.segments_read = num_segments;
+        local_stats.segments_read = region.num_segments;
 
         /* Initialize Loop Variables */
         RecordObject* batch_record = NULL;
@@ -515,7 +512,7 @@ void* Atl06Reader::subsettingThread (void* parm)
         int batch_index = 0;
 
         /* Loop Through Each Segment */
-        for(long segment = 0; reader->active && segment < num_segments; segment++)
+        for(long segment = 0; reader->active && segment < region.num_segments; segment++)
         {
             /* Create Elevation Batch Record */
             if(!batch_record)

--- a/plugins/icesat2/plugin/Atl06Reader.h
+++ b/plugins/icesat2/plugin/Atl06Reader.h
@@ -147,12 +147,12 @@ class Atl06Reader: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     latitude;
                 H5Array<double>     longitude;
@@ -169,7 +169,7 @@ class Atl06Reader: public LuaObject
         {
             public:
 
-                Atl06Data           (info_t* info, const Region& region);
+                Atl06Data           (const info_t* info, const Region& region);
                 ~Atl06Data          (void) = default;
 
                 /* Read Data */

--- a/plugins/icesat2/plugin/Atl13Reader.cpp
+++ b/plugins/icesat2/plugin/Atl13Reader.cpp
@@ -229,7 +229,7 @@ Atl13Reader::~Atl13Reader (void)
 /*----------------------------------------------------------------------------
  * Region::Constructor
  *----------------------------------------------------------------------------*/
-Atl13Reader::Region::Region (info_t* info):
+Atl13Reader::Region::Region (const info_t* info):
     latitude        (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "segment_lat").c_str(), &info->reader->context),
     longitude       (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "segment_lon").c_str(), &info->reader->context),
     inclusion_mask  {NULL},
@@ -297,7 +297,7 @@ void Atl13Reader::Region::cleanup (void)
 /*----------------------------------------------------------------------------
  * Region::polyregion
  *----------------------------------------------------------------------------*/
-void Atl13Reader::Region::polyregion (info_t* info)
+void Atl13Reader::Region::polyregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -343,7 +343,7 @@ void Atl13Reader::Region::polyregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
-void Atl13Reader::Region::rasterregion (info_t* info)
+void Atl13Reader::Region::rasterregion (const info_t* info)
 {
     /* Find First Segment In Polygon */
     bool first_segment_found = false;
@@ -398,7 +398,7 @@ void Atl13Reader::Region::rasterregion (info_t* info)
 /*----------------------------------------------------------------------------
  * Atl13Data::Constructor
  *----------------------------------------------------------------------------*/
-Atl13Reader::Atl13Data::Atl13Data (info_t* info, const Region& region):
+Atl13Reader::Atl13Data::Atl13Data (const info_t* info, const Region& region):
     sc_orient               (info->reader->asset, info->reader->resource,                                "/orbit_info/sc_orient",           &info->reader->context),
     delta_time              (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "delta_time").c_str(),             &info->reader->context, 0, region.first_segment, region.num_segments),
     segment_id_beg          (info->reader->asset, info->reader->resource, FString("%s/%s", info->prefix, "segment_id_beg").c_str(),         &info->reader->context, 0, region.first_segment, region.num_segments),
@@ -464,9 +464,9 @@ Atl13Reader::Atl13Data::~Atl13Data (void) = default;
 void* Atl13Reader::subsettingThread (void* parm)
 {
     /* Get Thread Info */
-    info_t* info = static_cast<info_t*>(parm);
+    const info_t* info = static_cast<info_t*>(parm);
     Atl13Reader* reader = info->reader;
-    Icesat2Parms* parms = reader->parms;
+    const Icesat2Parms* parms = reader->parms;
     stats_t local_stats = {0, 0, 0, 0, 0};
     vector<RecordObject*> rec_vec;
 

--- a/plugins/icesat2/plugin/Atl13Reader.cpp
+++ b/plugins/icesat2/plugin/Atl13Reader.cpp
@@ -256,7 +256,7 @@ Atl13Reader::Region::Region (info_t* info):
         }
         else
         {
-            return; // early exit since no subsetting required
+            num_segments = MIN(latitude.size, longitude.size);
         }
 
         /* Check If Anything to Process */
@@ -482,11 +482,8 @@ void* Atl13Reader::subsettingThread (void* parm)
         /* Read ATL06 Datasets */
         const Atl13Data atl13(info, region);
 
-        /* Get Number of Segments */
-        const long num_segments = region.num_segments != H5Coro::ALL_ROWS ? region.num_segments : atl13.delta_time.size;
-
         /* Increment Read Statistics */
-        local_stats.segments_read = num_segments;
+        local_stats.segments_read = region.num_segments;
 
         /* Initialize Loop Variables */
         RecordObject* batch_record = NULL;
@@ -495,7 +492,7 @@ void* Atl13Reader::subsettingThread (void* parm)
         int batch_index = 0;
 
         /* Loop Through Each Segment */
-        for(long segment = 0; reader->active && segment < num_segments; segment++)
+        for(long segment = 0; reader->active && segment < region.num_segments; segment++)
         {
             /* Create Elevation Batch Record */
             if(!batch_record)

--- a/plugins/icesat2/plugin/Atl13Reader.cpp
+++ b/plugins/icesat2/plugin/Atl13Reader.cpp
@@ -482,8 +482,11 @@ void* Atl13Reader::subsettingThread (void* parm)
         /* Read ATL06 Datasets */
         const Atl13Data atl13(info, region);
 
+        /* Get Number of Segments */
+        const long num_segments = region.num_segments != H5Coro::ALL_ROWS ? region.num_segments : atl13.delta_time.size;
+
         /* Increment Read Statistics */
-        local_stats.segments_read = region.num_segments;
+        local_stats.segments_read = num_segments;
 
         /* Initialize Loop Variables */
         RecordObject* batch_record = NULL;
@@ -492,7 +495,7 @@ void* Atl13Reader::subsettingThread (void* parm)
         int batch_index = 0;
 
         /* Loop Through Each Segment */
-        for(long segment = 0; reader->active && segment < region.num_segments; segment++)
+        for(long segment = 0; reader->active && segment < num_segments; segment++)
         {
             /* Create Elevation Batch Record */
             if(!batch_record)
@@ -518,7 +521,7 @@ void* Atl13Reader::subsettingThread (void* parm)
             entry->longitude                = region.longitude[segment];
             entry->snow_ice_atl09           = atl13.snow_ice_atl09[segment];
             entry->cloud_flag_asr_atl09     = atl13.cloud_flag_asr_atl09[segment];
-            entry->ht_ortho                 = atl13.ht_ortho[segment]               != numeric_limits<float>::max() ? atl13.ht_ortho[segment]                   : numeric_limits<float>::quiet_NaN();
+            entry->ht_ortho                 = atl13.ht_ortho[segment]               != numeric_limits<float>::max()   ? atl13.ht_ortho[segment]                 : numeric_limits<float>::quiet_NaN();
             entry->ht_water_surf            = atl13.ht_water_surf[segment]          != numeric_limits<float>::max()   ? atl13.ht_water_surf[segment]            : numeric_limits<float>::quiet_NaN();
             entry->segment_azimuth          = atl13.segment_azimuth[segment]        != numeric_limits<float>::max()   ? atl13.segment_azimuth[segment]          : numeric_limits<float>::quiet_NaN();
             entry->segment_quality          = nomial_segment_quality                != numeric_limits<int32_t>::max() ? atl13.segment_quality[segment]          : 0;

--- a/plugins/icesat2/plugin/Atl13Reader.cpp
+++ b/plugins/icesat2/plugin/Atl13Reader.cpp
@@ -256,7 +256,7 @@ Atl13Reader::Region::Region (const info_t* info):
         }
         else
         {
-            num_segments = MIN(latitude.size, longitude.size);
+            num_segments = latitude.size;
         }
 
         /* Check If Anything to Process */

--- a/plugins/icesat2/plugin/Atl13Reader.h
+++ b/plugins/icesat2/plugin/Atl13Reader.h
@@ -140,12 +140,12 @@ class Atl13Reader: public LuaObject
         {
             public:
 
-                explicit Region     (info_t* info);
+                explicit Region     (const info_t* info);
                 ~Region             (void);
 
                 void cleanup        (void);
-                void polyregion     (info_t* info);
-                void rasterregion   (info_t* info);
+                void polyregion     (const info_t* info);
+                void rasterregion   (const info_t* info);
 
                 H5Array<double>     latitude;
                 H5Array<double>     longitude;
@@ -162,7 +162,7 @@ class Atl13Reader: public LuaObject
         {
             public:
 
-                Atl13Data           (info_t* info, const Region& region);
+                Atl13Data           (const info_t* info, const Region& region);
                 ~Atl13Data          (void);
 
                 /* Read Data */

--- a/plugins/icesat2/selftests/atl03_ancillary.lua
+++ b/plugins/icesat2/selftests/atl03_ancillary.lua
@@ -35,7 +35,9 @@ while true do
     runner.check(rec:getvalue("count") == 2, rec:getvalue("count"))
 end
 
-runner.check(cnt >= 16697, "failed to read sufficient number of contaner records")
+-- runner.check(cnt >= 16697, "failed to read sufficient number of container records")
+runner.check(cnt >= 21748, "failed to read sufficient number of container records")
+print("cnt: ", cnt)
 
 -- Clean Up --
 

--- a/plugins/icesat2/selftests/atl03_ancillary.lua
+++ b/plugins/icesat2/selftests/atl03_ancillary.lua
@@ -35,10 +35,8 @@ while true do
     runner.check(rec:getvalue("count") == 2, rec:getvalue("count"))
 end
 
--- runner.check(cnt >= 16697, "failed to read sufficient number of container records")
-runner.check(cnt >= 21748, "failed to read sufficient number of container records")
-print("cnt: ", cnt)
-
+local expected_cnt = 21748
+runner.check(cnt == expected_cnt, string.format('failed to read sufficient number of container records, expected: %d, got: %d', expected_cnt, cnt))
 -- Clean Up --
 
 recq:destroy()

--- a/plugins/swot/plugin/SwotL2Reader.cpp
+++ b/plugins/swot/plugin/SwotL2Reader.cpp
@@ -236,7 +236,7 @@ SwotL2Reader::Region::Region (Asset* asset, const char* resource, const SwotParm
     }
     else
     {
-        num_lines = MIN(lat.size, lon.size);
+        num_lines = lat.size;
     }
 
     /* Trim Geospatial Datasets Read from File */

--- a/plugins/swot/plugin/SwotL2Reader.cpp
+++ b/plugins/swot/plugin/SwotL2Reader.cpp
@@ -211,7 +211,7 @@ SwotL2Reader::~SwotL2Reader (void)
 /*----------------------------------------------------------------------------
  * Region::Constructor
  *----------------------------------------------------------------------------*/
-SwotL2Reader::Region::Region (Asset* asset, const char* resource, SwotParms* _parms, H5Coro::context_t* context):
+SwotL2Reader::Region::Region (Asset* asset, const char* resource, const SwotParms* _parms, H5Coro::context_t* context):
     lat             (asset, resource, "latitude_nadir", context),
     lon             (asset, resource, "longitude_nadir", context),
     inclusion_mask  (NULL),
@@ -263,7 +263,7 @@ void SwotL2Reader::Region::cleanup (void) const
 /*----------------------------------------------------------------------------
  * Region::polyregion
  *----------------------------------------------------------------------------*/
-void SwotL2Reader::Region::polyregion (SwotParms* _parms)
+void SwotL2Reader::Region::polyregion (const SwotParms* _parms)
 {
     /* Find First and Last Lines in Polygon */
     bool first_line_found = false;
@@ -310,7 +310,7 @@ void SwotL2Reader::Region::polyregion (SwotParms* _parms)
 /*----------------------------------------------------------------------------
  * Region::rasterregion
  *----------------------------------------------------------------------------*/
-void SwotL2Reader::Region::rasterregion (SwotParms* _parms)
+void SwotL2Reader::Region::rasterregion (const SwotParms* _parms)
 {
     /* Allocate Inclusion Mask */
     if(lat.size <= 0) return;

--- a/plugins/swot/plugin/SwotL2Reader.h
+++ b/plugins/swot/plugin/SwotL2Reader.h
@@ -130,12 +130,12 @@ class SwotL2Reader: public LuaObject
         /* Region Subclass */
         struct Region
         {
-            Region              (Asset* asset, const char* resource, SwotParms* _parms, H5Coro::context_t* context);
+            Region              (Asset* asset, const char* resource, const SwotParms* _parms, H5Coro::context_t* context);
             ~Region             (void);
 
             void cleanup        (void) const;
-            void polyregion     (SwotParms* _parms);
-            void rasterregion   (SwotParms* _parms);
+            void polyregion     (const SwotParms* _parms);
+            void rasterregion   (const SwotParms* _parms);
 
             H5Array<int32_t>    lat;
             H5Array<int32_t>    lon;


### PR DESCRIPTION
Granules with no AOI are correctly read by plugins.
