### PR TITLE
code cleanup for building with latest tools

### DIFF
--- a/packages/h5/H5Array.h
+++ b/packages/h5/H5Array.h
@@ -161,9 +161,9 @@ bool H5Array<T>::join(int timeout, bool throw_exception)
             /*
              * There is no way to do this in a portable "safe" way. The code
              * below works because our target architectures are x86_64 and aarch64.
-             * The data pointed to by info.data is new'ed and therefore guaranteed
-             * to be aligned to a 16 byte boundary.  The calling code is responsible
-             * for knowing what the data being read out of the h5 file is and
+             * The data pointed to by info.data is new'ed with H5CORO_DATA_ALIGNMENT alignment.
+             * The calling code is responsible for knowing
+             * what the data being read out of the h5 file is and
              * providing the correct type to the template.
              */
             data = reinterpret_cast<T*>(h5f->info.data);

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -83,7 +83,7 @@ H5Coro::Future::Future (void)
     info.datasize   = 0;
     info.data       = NULL;
     info.datatype   = RecordObject::INVALID_FIELD;
-    
+
     for(int d = 0; d < MAX_NDIMS; d++)
     {
         info.shape[d] = 0;
@@ -147,7 +147,7 @@ H5Coro::Future::rc_t H5Coro::Future::wait (int timeout)
  * Constructor
  *  - assumes that asset is in scope for the duration this object is in scope
  *----------------------------------------------------------------------------*/
-H5Coro::Context::Context (Asset* asset, const char* resource):
+H5Coro::Context::Context (const Asset* asset, const char* resource):
     name                (NULL),
     ioDriver            (NULL),
     l1                  (IO_CACHE_L1_ENTRIES, hashL1),
@@ -167,7 +167,7 @@ H5Coro::Context::Context (Asset* asset, const char* resource):
         delete [] name;
         mlog(e.level(), "Failed to create H5 context: %s", e.what());
         throw;
-    }    
+    }
 }
 
 /*----------------------------------------------------------------------------
@@ -456,6 +456,9 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
 {
     info_t info;
 
+    memset(&info, 0, sizeof(info_t));
+    info.datatype = RecordObject::INVALID_FIELD;
+
     /* Start Trace */
     const uint32_t trace_id = start_trace(INFO, parent_trace_id, "h5coro_read", "{\"context\":\"%s\", \"dataset\":\"%s\"}", context->name, datasetname);
 
@@ -474,7 +477,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Float to Long */
             if(info.datatype == RecordObject::FLOAT)
             {
-                float* dptr = reinterpret_cast<float*>(info.data);
+                const float* dptr = reinterpret_cast<float*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -483,7 +486,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Double to Long */
             else if(info.datatype == RecordObject::DOUBLE)
             {
-                double* dptr = reinterpret_cast<double*>(info.data);
+                const double* dptr = reinterpret_cast<double*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -492,7 +495,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Char to Long */
             else if(info.datatype == RecordObject::INT8)
             {
-                int8_t* cptr = reinterpret_cast<int8_t*>(info.data);
+                const int8_t* cptr = reinterpret_cast<int8_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(cptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -500,7 +503,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT8)
             {
-                uint8_t* cptr = reinterpret_cast<uint8_t*>(info.data);
+                const uint8_t* cptr = info.data;
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(cptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -527,7 +530,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Short to Long */
             else if(info.datatype == RecordObject::INT16)
             {
-                int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
+                const int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -535,7 +538,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT16)
             {
-                uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
+                const uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -544,7 +547,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Int to Long */
             else if(info.datatype == RecordObject::INT32)
             {
-                int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
+                const int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -552,7 +555,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT32)
             {
-                uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
+                const uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -561,7 +564,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Long to Long */
             else if(info.datatype == RecordObject::INT64)
             {
-                int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
+                const int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -569,7 +572,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT64)
             {
-                uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
+                const uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -595,7 +598,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Float to Double */
             if(info.datatype == RecordObject::FLOAT)
             {
-                float* dptr = reinterpret_cast<float*>(info.data);
+                const float* dptr = reinterpret_cast<float*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -604,7 +607,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Double to Double */
             else if(info.datatype == RecordObject::DOUBLE)
             {
-                double* dptr = reinterpret_cast<double*>(info.data);
+                const double* dptr = reinterpret_cast<double*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -613,7 +616,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Char to Double */
             else if(info.datatype == RecordObject::INT8)
             {
-                int8_t* dptr = reinterpret_cast<int8_t*>(info.data);
+                const int8_t* dptr = reinterpret_cast<int8_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -621,7 +624,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT8)
             {
-                uint8_t* dptr = reinterpret_cast<uint8_t*>(info.data);
+                const uint8_t* dptr = info.data;
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -630,7 +633,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Short to Double */
             else if(info.datatype == RecordObject::INT16)
             {
-                int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
+                const int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -638,7 +641,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT16)
             {
-                uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
+                const uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -647,7 +650,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Int to Double */
             else if(info.datatype == RecordObject::INT32)
             {
-                int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
+                const int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -655,7 +658,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT32)
             {
-                uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
+                const uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -664,7 +667,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Long to Double */
             else if(info.datatype == RecordObject::INT64)
             {
-                int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
+                const int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -672,7 +675,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT64)
             {
-                uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
+                const uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -99,7 +99,7 @@ H5Coro::Future::Future (void)
 H5Coro::Future::~Future (void)
 {
     wait(IO_PEND);
-    delete [] info.data;
+    operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
 }
 
 /*----------------------------------------------------------------------------
@@ -456,9 +456,6 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
 {
     info_t info;
 
-    memset(&info, 0, sizeof(info_t));
-    info.datatype = RecordObject::INVALID_FIELD;
-
     /* Start Trace */
     const uint32_t trace_id = start_trace(INFO, parent_trace_id, "h5coro_read", "{\"context\":\"%s\", \"dataset\":\"%s\"}", context->name, datasetname);
 
@@ -472,7 +469,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
         if(valtype == RecordObject::INTEGER)
         {
             /* Allocate Buffer of Integers */
-            long* tbuf = new long [info.elements];
+            long* tbuf = new (std::align_val_t(H5CORO_DATA_ALIGNMENT)) long [info.elements];
 
             /* Float to Long */
             if(info.datatype == RecordObject::FLOAT)
@@ -585,15 +582,15 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
 
             /* Switch Buffers */
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = reinterpret_cast<uint8_t*>(tbuf);
             info.datasize = sizeof(long) * info.elements;
         }
         /* Perform Integer Type Transaltion */
         else if(valtype == RecordObject::REAL)
         {
-            /* Allocate Buffer of Integers */
-            double* tbuf = new double [info.elements];
+            /* Allocate Buffer of doubles */
+            double* tbuf = new (std::align_val_t(H5CORO_DATA_ALIGNMENT)) double [info.elements];
 
             /* Float to Double */
             if(info.datatype == RecordObject::FLOAT)
@@ -688,7 +685,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
 
             /* Switch Buffers */
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = reinterpret_cast<uint8_t*>(tbuf);
             info.datasize = sizeof(double) * info.elements;
         }
@@ -696,7 +693,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
         /* Check Data Valid */
         if(!data_valid)
         {
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = NULL;
             info.datasize = 0;
             throw RunTimeException(CRITICAL, RTE_ERROR, "data translation failed for %s: [%d] %d --> %d", datasetname, info.typesize, (int)info.datatype, (int)valtype);

--- a/packages/h5/H5Coro.h
+++ b/packages/h5/H5Coro.h
@@ -70,6 +70,10 @@
 #define H5CORO_ENABLE_FILL false
 #endif
 
+#ifndef H5CORO_DATA_ALIGNMENT
+#define H5CORO_DATA_ALIGNMENT 8
+#endif
+
 /******************************************************************************
  * MACRO
  ******************************************************************************/
@@ -99,7 +103,7 @@ namespace H5Coro
         uint32_t                    elements;   // number of elements in dataset
         uint32_t                    typesize;   // number of bytes per element
         uint64_t                    datasize;   // total number of bytes in dataset
-        uint8_t*                    data;       // point to allocated data buffer
+        uint8_t*                    data;       // point to allocated data buffer - must be H5CORO_DATA_ALIGNMENT aligned
         RecordObject::fieldType_t   datatype;   // data type of elements
         int64_t                     shape[MAX_NDIMS]; // dimensions of the data
     } info_t;

--- a/packages/h5/H5Coro.h
+++ b/packages/h5/H5Coro.h
@@ -86,7 +86,7 @@ namespace H5Coro
     * Constants
     *--------------------------------------------------------------------*/
 
-    const int MAX_NDIMS = H5CORO_MAXIMUM_DIMENSIONS;    
+    const int MAX_NDIMS = H5CORO_MAXIMUM_DIMENSIONS;
     const long EOR = -1L; // end of range - read rest of the span of a dimension
     const long ALL_ROWS = EOR;
     const long ALL_COLS = EOR;
@@ -190,7 +190,7 @@ namespace H5Coro
         /* Methods */
         /***********/
 
-                        Context     (Asset* asset, const char* resource);
+                        Context     (const Asset* asset, const char* resource);
                         ~Context    (void);
 
         void            ioRequest   (uint64_t* pos, int64_t size, uint8_t* buffer, int64_t hint, bool cache);

--- a/packages/h5/H5Dataset.cpp
+++ b/packages/h5/H5Dataset.cpp
@@ -69,7 +69,7 @@ Mutex H5Dataset::metaMutex;
 /*----------------------------------------------------------------------------
  * Constructor
  *----------------------------------------------------------------------------*/
-H5Dataset::H5Dataset (info_t* info, Context* context, 
+H5Dataset::H5Dataset (info_t* info, Context* context,
                       const char* dataset, const range_t* slice, int slicendims,
                       bool _meta_only):
     ioContext (context),
@@ -296,7 +296,7 @@ void H5Dataset::readDataset (info_t* info)
             (hyperslice[d].r1 > metaData.dimensions[d]) ||
             (hyperslice[d].r0 < 0) )
         {
-            throw RunTimeException(CRITICAL, RTE_ERROR, "Invalid hyperslice at dimension %d [%ld]: [%ld, %ld)", d, metaData.dimensions[d], hyperslice[d].r0, hyperslice[d].r1);            
+            throw RunTimeException(CRITICAL, RTE_ERROR, "Invalid hyperslice at dimension %d [%ld]: [%ld, %ld)", d, metaData.dimensions[d], hyperslice[d].r0, hyperslice[d].r1);
         }
     }
 
@@ -324,7 +324,7 @@ void H5Dataset::readDataset (info_t* info)
         /* Gaurantee Termination of String */
         if(metaData.type == STRING_TYPE)
         {
-            buffer[buffer_size] = '\0'; 
+            buffer[buffer_size] = '\0';
         }
 
         /* Fill Buffer with Fill Value (if provided) */
@@ -484,7 +484,7 @@ void H5Dataset::readDataset (info_t* info)
                 for(int d = metaData.ndims - 1; d > 0; d--)
                 {
                     chunkStepSize[d - 1] = dimensionsInChunks[d] * chunkStepSize[d];
-                }            
+                }
 
                 /* Calculate position of first and last element in hyperslice */
                 hypersliceChunkStart = 0;
@@ -1286,7 +1286,7 @@ int H5Dataset::readBTreeV1 (uint64_t pos, uint8_t* buffer, uint64_t buffer_size)
                     // decompress
                     inflateChunk(dataChunkFilterBuffer, curr_node.chunk_size, dataChunkBuffer, dataChunkBufferSize);
                     chunk_buffer = dataChunkBuffer; // sets chunk buffer to new output
-                    
+
                     // unshuffle
                     if(metaData.filter[SHUFFLE_FILTER])
                     {
@@ -1295,7 +1295,7 @@ int H5Dataset::readBTreeV1 (uint64_t pos, uint8_t* buffer, uint64_t buffer_size)
                     }
                 }
 
-                // get truncated slice to pull out of chunk 
+                // get truncated slice to pull out of chunk
                 // (intersection of chunk_slice and hyperslice selection)
                 range_t chunk_slice_to_read[MAX_NDIMS];
                 for(int d = 0; d < metaData.ndims; d++)
@@ -3053,7 +3053,7 @@ bool H5Dataset::hypersliceIntersection(const range_t* node_slice, const uint8_t 
 /*----------------------------------------------------------------------------
  * type2str
  *----------------------------------------------------------------------------*/
-void H5Dataset::readSlice (uint8_t* output_buffer, const int64_t* output_dimensions, const range_t* output_slice, 
+void H5Dataset::readSlice (uint8_t* output_buffer, const int64_t* output_dimensions, const range_t* output_slice,
                            const uint8_t* input_buffer, const int64_t* input_dimensions, const range_t* input_slice) const
 {
     assert(metaData.ndims > 1); // this code should never be called when ndims is 0 or 1

--- a/packages/h5/H5Dataset.cpp
+++ b/packages/h5/H5Dataset.cpp
@@ -166,7 +166,7 @@ H5Dataset::H5Dataset (info_t* info, Context* context,
     catch(const RunTimeException& e)
     {
         /* Clean Up Data Allocations */
-        delete [] info->data;
+        operator delete [] (info->data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
         info->data= NULL;
         info->datasize = 0;
 
@@ -319,7 +319,7 @@ void H5Dataset::readDataset (info_t* info)
         const int64_t extra_space_for_terminator = (metaData.type == STRING_TYPE);
 
         /* Allocate */
-        buffer = new uint8_t [buffer_size + extra_space_for_terminator];
+        buffer = new (std::align_val_t(H5CORO_DATA_ALIGNMENT)) uint8_t [buffer_size + extra_space_for_terminator];
 
         /* Gaurantee Termination of String */
         if(metaData.type == STRING_TYPE)

--- a/packages/h5/H5DatasetDevice.cpp
+++ b/packages/h5/H5DatasetDevice.cpp
@@ -184,7 +184,7 @@ bool H5DatasetDevice::isConnected (int num_open)
 void H5DatasetDevice::closeConnection (void)
 {
     connected = false;
-    delete [] dataBuffer;
+    operator delete[](dataBuffer, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     dataBuffer = NULL;
 }
 

--- a/packages/h5/H5Element.h
+++ b/packages/h5/H5Element.h
@@ -90,7 +90,7 @@ H5Element<T>::H5Element(H5Coro::Context* context, const char* variable)
 {
     memset(&value, 0, sizeof(T));
     size = 0;
-    H5Coro::range_t slice[1] = {{0, H5Coro::EOR}};
+    const H5Coro::range_t slice[1] = {{0, H5Coro::EOR}};
     if(context) h5f = H5Coro::readp(context, variable, RecordObject::DYNAMIC, slice, 1);
     else        h5f = NULL;
 }

--- a/packages/h5/H5File.cpp
+++ b/packages/h5/H5File.cpp
@@ -162,7 +162,7 @@ void* H5File::readThread (void* parm)
         }
 
         /* Clean Up Result Data */
-        delete [] results.data;
+        operator delete[](results.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     }
 
     /* Clean Up Thread Info */

--- a/plugins/icesat2/plugin/BathyOceanEyes.cpp
+++ b/plugins/icesat2/plugin/BathyOceanEyes.cpp
@@ -118,7 +118,7 @@ void BathyOceanEyes::init (void)
         {
             /* get uncertainty filename */
             const char* uncertainty_filename = TU_FILENAMES[tu_dimension_index][pointing_angle_index];
-            
+
             /* open csv file */
             fileptr_t file = fopen(uncertainty_filename, "r");
             if(!file)
@@ -170,9 +170,9 @@ void BathyOceanEyes::init (void)
                             coeff_sum.b += tu[i].b;
                             coeff_sum.c += tu[i].c;
                             count += 1.0;
-                        } 
+                        }
                     }
-                    
+
                     /* check count */
                     if(count <= 0)
                     {
@@ -266,7 +266,7 @@ BathyOceanEyes::BathyOceanEyes (lua_State* L, int index):
         /* model as poisson */
         lua_getfield(L, index, OCEANEYES_PARMS_MODEL_AS_POISSON);
         parms.model_as_poisson = LuaObject::getLuaBoolean(L, -1, true, parms.model_as_poisson, NULL);
-        lua_pop(L, 1);        
+        lua_pop(L, 1);
     }
 
     /* Open Kd Resource */
@@ -512,45 +512,45 @@ void BathyOceanEyes::findSeaSurface (extent_t& extent) const
 }
 
 /*----------------------------------------------------------------------------
- * photon_refraction - 
- * 
- * ICESat-2 refraction correction implemented as outlined in Parrish, et al. 
- * 2019 for correcting photon depth data. Reference elevations are to geoid datum 
+ * photon_refraction -
+ *
+ * ICESat-2 refraction correction implemented as outlined in Parrish, et al.
+ * 2019 for correcting photon depth data. Reference elevations are to geoid datum
  * to remove sea surface variations.
- * 
+ *
  * https://www.mdpi.com/2072-4292/11/14/1634
  *
  * ----------------------------------------------------------------------------
  * The code below was adapted from https://github.com/ICESat2-Bathymetry/Information.git
  * with the associated license replicated here:
  * ----------------------------------------------------------------------------
- * 
+ *
  * Copyright (c) 2022, Jonathan Markel/UT Austin.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * Neither the name of the copyright holder nor the names of its 
- * contributors may be used to endorse or promote products derived from this 
- * software without specific prior written permission. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR '
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *----------------------------------------------------------------------------*/
 void BathyOceanEyes::correctRefraction(extent_t& extent) const
@@ -578,7 +578,7 @@ void BathyOceanEyes::correctRefraction(extent_t& extent) const
             const double dZ = p * sin(beta);                            // vertical offset
             const double dY = p * cos(beta);                            // cross-track offset
             const double dE = dY * sin(static_cast<double>(photons[i].ref_az));              // UTM offsets
-            const double dN = dY * cos(static_cast<double>(photons[i].ref_az)); 
+            const double dN = dY * cos(static_cast<double>(photons[i].ref_az));
 
             /* Apply Refraction Corrections */
             photons[i].x_ph += dE;
@@ -598,7 +598,7 @@ void BathyOceanEyes::correctRefraction(extent_t& extent) const
  *----------------------------------------------------------------------------*/
 void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
 {
-    if(extent.photon_count <= 0) return; // nothing to do
+    if(extent.photon_count == 0) return; // nothing to do
 
     /* join kd resource read */
     Kd_490->join(parms.read_timeout_ms, true);
@@ -628,7 +628,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
         /* initialize total uncertainty to aerial uncertainty */
         photons[i].sigma_thu = sqrtf((photons[i].sigma_across * photons[i].sigma_across) + (photons[i].sigma_along * photons[i].sigma_along));
         photons[i].sigma_tvu = photons[i].sigma_h;
-        
+
         /* calculate subaqueous uncertainty */
         const double depth = extent.surface_h - photons[i].ortho_h;
         if(depth > 0.0)
@@ -637,7 +637,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
             int pointing_angle_index = static_cast<int>(roundf(photons[i].pointing_angle));
             if(pointing_angle_index < 0) pointing_angle_index = 0;
             else if(pointing_angle_index >= NUM_POINTING_ANGLES) pointing_angle_index = NUM_POINTING_ANGLES - 1;
-            
+
             /* get wind speed index */
             int wind_speed_index = static_cast<int>(roundf(photons[i].wind_v)) - 1;
             if(wind_speed_index < 0) wind_speed_index = 0;
@@ -650,6 +650,9 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
                 kd_range_index++;
             }
 
+            /* check for out of range */
+            if(kd_range_index == NUM_KD_RANGES) kd_range_index = NUM_KD_RANGES - 1;
+
             /* uncertainty coefficients */
             const uncertainty_coeff_t horizontal_coeff = UNCERTAINTY_COEFF_MAP[THU][pointing_angle_index][wind_speed_index][kd_range_index];
             const uncertainty_coeff_t vertical_coeff = UNCERTAINTY_COEFF_MAP[TVU][pointing_angle_index][wind_speed_index][kd_range_index];
@@ -661,7 +664,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
             /* add subaqueous uncertainties to total uncertainties */
             photons[i].sigma_thu += subaqueous_horizontal_uncertainty;
             photons[i].sigma_tvu += subaqueous_vertical_uncertainty;
-            
+
             /* set maximum sensor depth processing flag */
             if(kd > 0)
             {

--- a/plugins/icesat2/plugin/BathyOceanEyes.cpp
+++ b/plugins/icesat2/plugin/BathyOceanEyes.cpp
@@ -645,13 +645,10 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
 
             /* get kd range index */
             int kd_range_index = 0;
-            while(kd_range_index < NUM_KD_RANGES && KD_RANGES[kd_range_index][1] < kd)
+            while(kd_range_index < (NUM_KD_RANGES - 1) && KD_RANGES[kd_range_index][1] < kd)
             {
                 kd_range_index++;
             }
-
-            /* check for out of range */
-            if(kd_range_index == NUM_KD_RANGES) kd_range_index = NUM_KD_RANGES - 1;
 
             /* uncertainty coefficients */
             const uncertainty_coeff_t horizontal_coeff = UNCERTAINTY_COEFF_MAP[THU][pointing_angle_index][wind_speed_index][kd_range_index];

--- a/plugins/icesat2/plugin/BathyOceanEyes.h
+++ b/plugins/icesat2/plugin/BathyOceanEyes.h
@@ -89,7 +89,7 @@ class BathyOceanEyes
                 highest_peak_ratio  (1.2),
                 surface_width       (3.0),
                 model_as_poisson    (true) {};
-            
+
             ~parms_t() {
                 if(assetKd) assetKd->releaseLuaObject();
                 delete [] resourceKd;

--- a/plugins/icesat2/plugin/BathyReader.cpp
+++ b/plugins/icesat2/plugin/BathyReader.cpp
@@ -257,7 +257,7 @@ void BathyReader::init (void)
 /*----------------------------------------------------------------------------
  * Constructor
  *----------------------------------------------------------------------------*/
-BathyReader::BathyReader (lua_State* L, const parms_t* _parms, const char* _resource, 
+BathyReader::BathyReader (lua_State* L, const parms_t* _parms, const char* _resource,
                           const char* outq_name, const char* shared_directory, bool _send_terminator):
     LuaObject(L, OBJECT_TYPE, LUA_META_NAME, LUA_META_TABLE),
     parms(_parms),
@@ -1151,7 +1151,7 @@ void* BathyReader::subsettingThread (void* parm)
 
                 /* Update Statistics */
                 local_stats.photon_count += extent->photon_count;
-                
+
                 /* Export Data */
                 if(parms->return_inputs)
                 {
@@ -1254,7 +1254,7 @@ void* BathyReader::subsettingThread (void* parm)
                         fprintf(out_file, "%d,", extent->photons[i].yapc_score);
                         fprintf(out_file, "%d,", extent->photons[i].max_signal_conf);
                         fprintf(out_file, "%d,", extent->photons[i].quality_ph);
-                        fprintf(out_file, "%d,", extent->photons[i].processing_flags);
+                        fprintf(out_file, "%u,", extent->photons[i].processing_flags);
                         fprintf(out_file, "%d", extent->photons[i].class_ph);
                         fprintf(out_file, "\n");
                     }

--- a/plugins/icesat2/plugin/BathyViewer.cpp
+++ b/plugins/icesat2/plugin/BathyViewer.cpp
@@ -205,7 +205,7 @@ BathyViewer::~BathyViewer (void)
     delete bathyMask;
 
     delete context;
-    
+
     parms->releaseLuaObject();
 
     delete [] resource;
@@ -328,7 +328,7 @@ int BathyViewer::luaCounts (lua_State* L)
 {
     bool status = false;
     int num_obj_to_return = 1;
-    BathyViewer* lua_obj = NULL;
+    const BathyViewer* lua_obj = NULL;
 
     try
     {

--- a/plugins/icesat2/plugin/MeritRaster.cpp
+++ b/plugins/icesat2/plugin/MeritRaster.cpp
@@ -172,7 +172,7 @@ uint32_t MeritRaster::getSamples (const MathLib::point_3d_t& point, int64_t gps,
         if(!value_cached)
         {
             H5Coro::Context context(asset, RESOURCE_NAME);
-            H5Coro::range_t slice[2] = {{0, H5Coro::EOR}, {0, H5Coro::EOR}};
+            const H5Coro::range_t slice[2] = {{0, H5Coro::EOR}, {0, H5Coro::EOR}};
             const H5Coro::info_t info = H5Coro::read(&context, dataset.c_str(), RecordObject::DYNAMIC, slice, 2, false, traceId);
             assert(info.datasize == (X_MAX * Y_MAX * sizeof(int32_t)));
             int32_t* tile = reinterpret_cast<int32_t*>(info.data);

--- a/plugins/icesat2/plugin/MeritRaster.cpp
+++ b/plugins/icesat2/plugin/MeritRaster.cpp
@@ -75,7 +75,7 @@ RasterObject* MeritRaster::create(lua_State* L, GeoParms* _parms)
  *----------------------------------------------------------------------------*/
 MeritRaster::~MeritRaster(void)
 {
-    delete [] cache;
+    operator delete[](cache, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     if(asset) asset->releaseLuaObject();
 }
 
@@ -180,7 +180,7 @@ uint32_t MeritRaster::getSamples (const MathLib::point_3d_t& point, int64_t gps,
             /* Update Cache */
             cacheMut.lock();
             {
-                delete [] cache;
+                operator delete[](cache, std::align_val_t(H5CORO_DATA_ALIGNMENT));
                 cache = tile;
                 cacheLon = left_lon;
                 cacheLat = upper_lat;

--- a/plugins/swot/plugin/SwotL2Reader.cpp
+++ b/plugins/swot/plugin/SwotL2Reader.cpp
@@ -146,7 +146,7 @@ SwotL2Reader::SwotL2Reader (lua_State* L, Asset* _asset, const char* _resource, 
     threadCount = 0;
 
     try
-    {  
+    {
         /* Create H5Coro Context */
         context = new H5Coro::Context(asset, resource);
 
@@ -194,7 +194,7 @@ SwotL2Reader::SwotL2Reader (lua_State* L, Asset* _asset, const char* _resource, 
             /* Terminate */
             checkComplete();
         }
-    }       
+    }
     catch(const RunTimeException& e)
     {
         mlog(CRITICAL, "Failed to create SWOT reader");
@@ -464,7 +464,7 @@ void* SwotL2Reader::varThread (void* parm)
     try
     {
         /* Read Dataset */
-        H5Coro::range_t slice[2] = {{reader->region->first_line, reader->region->first_line + reader->region->num_lines}, {0, H5Coro::EOR}};
+        const H5Coro::range_t slice[2] = {{reader->region->first_line, reader->region->first_line + reader->region->num_lines}, {0, H5Coro::EOR}};
         results = H5Coro::read(reader->context, info->variable_name, RecordObject::DYNAMIC, slice, 2, false, trace_id);
 
         /* Post Results to Output Queue */

--- a/plugins/swot/plugin/SwotL2Reader.cpp
+++ b/plugins/swot/plugin/SwotL2Reader.cpp
@@ -521,7 +521,7 @@ void* SwotL2Reader::varThread (void* parm)
     reader->checkComplete();
 
     /* Clean Up */
-    delete [] results.data;
+    operator delete[](results.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     delete [] info->variable_name;
     delete info;
 

--- a/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.cpp
+++ b/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.cpp
@@ -179,7 +179,7 @@ OGRErr Usgs3dep1meterDemRaster::overrideTargetCRS(OGRSpatialReference& target)
     const OGRErr er2 = vertical.importFromEPSG(NAVD88_HEIGHT_EPSG);
     const OGRErr er3 = target.SetCompoundCS("sliderule", &horizontal, &vertical);
 
-    if(((er1 == er2) == er3) == OGRERR_NONE)
+    if(er1 == OGRERR_NONE && er2 == OGRERR_NONE && er3 == OGRERR_NONE)
     {
         ogrerr = OGRERR_NONE;
     }

--- a/project-config.cmake
+++ b/project-config.cmake
@@ -126,6 +126,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         "--suppress=unreadVariable:*/TimeLib.cpp"                       # line: 471, terminating '\0' detected as 'unused' but it is used/needed
         "--suppress=invalidPointerCast:*/H5Array.h"                     # line: 166, documented in code
         "--suppress=invalidPointerCast:*/H5Element.h"                   # line: 141, documented in code
+        "--suppress=invalidPointerCast:*/H5Coro.cpp"                    # info.data (uint8_t* being cast to float/double ptrs. Allignments issues)
         "--suppress=copyCtorPointerCopying:*/MsgQ.cpp"                  # line: 120, shallow copy which is fine in code
         "--error-exitcode=1"
 
@@ -136,6 +137,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         "--suppress=constParameterReference:*/ArrowBuilderImpl.cpp"     # List [] const issue
         "--suppress=constParameterPointer:*/CcsdsPayloadDispatch.cpp"   # Not trivial to fix, would have to change DispachObject class as well.
         "--suppress=knownConditionTrueFalse"                            # -1 < 0 etc
+        "--suppress=constParameterReference:*/BathyOceanEyes.cpp"       # extent_t& extent cannot be const
     )
 
 endif()

--- a/project-config.cmake
+++ b/project-config.cmake
@@ -126,7 +126,8 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         "--suppress=unreadVariable:*/TimeLib.cpp"                       # line: 471, terminating '\0' detected as 'unused' but it is used/needed
         "--suppress=invalidPointerCast:*/H5Array.h"                     # line: 166, documented in code
         "--suppress=invalidPointerCast:*/H5Element.h"                   # line: 141, documented in code
-        "--suppress=invalidPointerCast:*/H5Coro.cpp"                    # info.data (uint8_t* being cast to float/double ptrs. Allignments issues)
+        "--suppress=invalidPointerCast:*/H5Coro.cpp"                    # info.data is newed on 8 byte boundries, can supress this warning
+        "--suppress=uninitvar:*/H5Coro.cpp"                             # info
         "--suppress=copyCtorPointerCopying:*/MsgQ.cpp"                  # line: 120, shallow copy which is fine in code
         "--error-exitcode=1"
 


### PR DESCRIPTION
H5Coro.cpp has an issue with info.data which is uint8_t* 
It gets allocation as byte array but later the pointer gets casted to float/double etc. This is not safe. Starting in C++ 17 'new' on byte array may be aligned to 2, 4, 8, 16 bytes. Before C++ 17 it was either 4 or 8 bytes. cpp-check is very unhappy about it. For now, I added this line to project-config.cmake to disable the warning:

"--suppress=invalidPointerCast:*/H5Coro.cpp"                    # info.data (uint8_t* being cast to float/double ptrs. Alignment issues)

We could ignore it (what we do now)
Allocate memory with with std::aligned_alloc() guaranteeing the max needed alignment. 

BathyOcensEyes.cpp line 653. Added check for kd_range_index value being out of bounds. cpp-check detected that UNCERTAINTY_COEFF_MAP may be indexed out of bounds.