### PR TITLE
integrated arrow sampler into the icesat2 and gedi endpoints

### DIFF
--- a/packages/arrow/ArrowBuilder.cpp
+++ b/packages/arrow/ArrowBuilder.cpp
@@ -75,7 +75,7 @@ int ArrowBuilder::luaCreate (lua_State* L)
         const char* id              = getLuaString(L, 5);
         const char* parms_str       = getLuaString(L, 6);
         const char* endpoint        = getLuaString(L, 7);
-        bool        keep_local      = getLuaBoolean(L, 8, true, false);
+        const bool  keep_local      = getLuaBoolean(L, 8, true, false);
 
         /* Create Dispatch */
         return createLuaObject(L, new ArrowBuilder(L, _parms, outq_name, inq_name, rec_type, id, parms_str, endpoint, keep_local));
@@ -532,7 +532,7 @@ void* ArrowBuilder::builderThread(void* parm)
 
     /* Check if Keeping Local
      *  when performing additional operations on the parquet file, like the ArrowSampler
-     *  we need to keep the temporary file on disk so that additional operations can 
+     *  we need to keep the temporary file on disk so that additional operations can
      *  be performed on it */
     if(!builder->keepLocal)
     {
@@ -564,7 +564,7 @@ int ArrowBuilder::luaGetFileNames (lua_State* L)
     try
     {
         /* Get Self */
-        ArrowBuilder* lua_obj = dynamic_cast<ArrowBuilder*>(getLuaSelf(L, 1));
+        const ArrowBuilder* lua_obj = dynamic_cast<ArrowBuilder*>(getLuaSelf(L, 1));
 
         /* Return Filenames */
         if(lua_obj->dataFile)       lua_pushstring(L, lua_obj->dataFile);

--- a/packages/arrow/ArrowBuilder.h
+++ b/packages/arrow/ArrowBuilder.h
@@ -172,6 +172,7 @@ class ArrowBuilder: public LuaObject
         const char*         outputMetadataPath; // final destination of the metadata file
         const char*         parmsAsString;
         const char*         endpoint;
+        const bool          keepLocal;
 
         ArrowBuilderImpl*   impl; // private arrow data
 
@@ -182,9 +183,11 @@ class ArrowBuilder: public LuaObject
                         ArrowBuilder            (lua_State* L, ArrowParms* parms,
                                                  const char* outq_name, const char* inq_name,
                                                  const char* rec_type, const char* id,
-                                                 const char* parms_str, const char* _endpoint);
+                                                 const char* parms_str, const char* _endpoint,
+                                                 const bool keep_local);
                         ~ArrowBuilder           (void) override;
         static void*    builderThread           (void* parm);
+        static int      luaGetFileNames         (lua_State* L);
 };
 
 #endif  /* __arrow_builder__ */

--- a/packages/arrow/ArrowSampler.h
+++ b/packages/arrow/ArrowSampler.h
@@ -109,10 +109,8 @@ class ArrowSampler: public LuaObject
          *--------------------------------------------------------------------*/
 
         static int                     luaCreate      (lua_State* L);
-        static int                     luaSample      (lua_State* L);
         static void                    init           (void);
         static void                    deinit         (void);
-        void                           sample         (void);
         const ArrowParms*              getParms       (void);
         const char*                    getDataFile    (void);
         const char*                    getMetadataFile(void);
@@ -128,9 +126,10 @@ class ArrowSampler: public LuaObject
          * Data
          *--------------------------------------------------------------------*/
 
+        bool                       active;
+        Thread*                    mainPid;
         ArrowParms*                parms;
         Publisher*                 outQ;
-        std::vector<Thread*>       samplerPids;
         std::vector<point_info_t*> points;
         std::vector<sampler_t*>    samplers;
         ArrowSamplerImpl*          impl;
@@ -138,7 +137,6 @@ class ArrowSampler: public LuaObject
         const char*                metadataFile;       // used locally to build json metadata file
         const char*                outputPath;         // final destination of the data file
         const char*                outputMetadataPath; // final destination of the metadata file
-        bool                       alreadySampled;
 
         /*--------------------------------------------------------------------
          * Methods
@@ -148,6 +146,7 @@ class ArrowSampler: public LuaObject
                                                const char* outq_name, const std::vector<raster_info_t>& rasters);
                         ~ArrowSampler         (void) override;
         void            Delete                (void);
+        static void*    mainThread            (void* parm);
         static void*    samplerThread         (void* parm);
 };
 

--- a/packages/arrow/ArrowSamplerImpl.cpp
+++ b/packages/arrow/ArrowSamplerImpl.cpp
@@ -300,6 +300,7 @@ void ArrowSamplerImpl::getXYPoints(std::vector<ArrowSampler::point_info_t*>& poi
         ArrowSampler::point_info_t* pinfo = new ArrowSampler::point_info_t({x, y, 0.0});
         points.push_back(pinfo);
     }
+    mlog(INFO, "Read %ld points from file", points.size());
 }
 
 /*----------------------------------------------------------------------------
@@ -328,6 +329,7 @@ void ArrowSamplerImpl::getGeoPoints(std::vector<ArrowSampler::point_info_t*>& po
         ArrowSampler::point_info_t* pinfo = new ArrowSampler::point_info_t({point.x, point.y, 0.0});
         points.push_back(pinfo);
     }
+    mlog(INFO, "Read %ld geo points from file", points.size());
 }
 
 /*----------------------------------------------------------------------------

--- a/packages/geo/GeoIndexedRaster.h
+++ b/packages/geo/GeoIndexedRaster.h
@@ -53,8 +53,10 @@ class GeoIndexedRaster: public RasterObject
          * Constants
          *--------------------------------------------------------------------*/
 
+        static const int   MAX_CACHE_SIZE     = 20;
         static const int   MAX_READER_THREADS = 200;
         static const int   MAX_FINDER_THREADS  = 16;
+        static const int   MIN_FEATURES_PER_FINDER_THREAD = 10;
 
         static const char* FLAGS_TAG;
         static const char* VALUE_TAG;
@@ -226,11 +228,11 @@ class GeoIndexedRaster: public RasterObject
         static void*    readerThread    (void *param);
 
         bool            createFinderThreads (void);
-        bool            createReaderThreads (void);
-        bool            updateCache     (void);
-        bool            filterRasters   (int64_t gps);
-        void            setFindersRange (void);
-        bool            findAndFilterRasters (OGRGeometry* geo, int64_t gps);
+        bool            createReaderThreads (uint32_t  rasters2sample);
+        bool            updateCache         (uint32_t& rasters2sample);
+        bool            filterRasters       (int64_t gps);
+        void            setFindersRange     (void);
+        bool            findAndFilterRasters(OGRGeometry* geo, int64_t gps);
 };
 
 #endif  /* __geo_indexed_raster__ */

--- a/packages/geo/GeoIndexedRaster.h
+++ b/packages/geo/GeoIndexedRaster.h
@@ -53,13 +53,14 @@ class GeoIndexedRaster: public RasterObject
          * Constants
          *--------------------------------------------------------------------*/
 
-        static const int   MAX_CACHE_SIZE     = 20;
+        static const int   MAX_CACHE_SIZE     =  20;
         static const int   MAX_READER_THREADS = 200;
-        static const int   MAX_FINDER_THREADS  = 16;
+        static const int   MAX_FINDER_THREADS =  16;
         static const int   MIN_FEATURES_PER_FINDER_THREAD = 10;
 
         static const char* FLAGS_TAG;
         static const char* VALUE_TAG;
+        static const char* DATE_TAG;
 
         /*--------------------------------------------------------------------
          * Typedefs
@@ -161,6 +162,7 @@ class GeoIndexedRaster: public RasterObject
         uint32_t        getGroupFlags         (const rasters_group_t* rgroup);
         static double   getGmtDate            (const OGRFeature* feature, const char* field,  TimeLib::gmt_time_t& gmtDate);
         virtual bool    openGeoIndex          (const OGRGeometry* geo);
+        virtual bool    getFeatureDate        (const OGRFeature* feature, TimeLib::gmt_time_t& gmtDate);
         virtual void    getIndexFile          (const OGRGeometry* geo, std::string& file) = 0;
         virtual bool    findRasters           (finder_t* finder) = 0;
         void            sampleRasters         (OGRGeometry* geo);
@@ -212,9 +214,10 @@ class GeoIndexedRaster: public RasterObject
         uint32_t                  rows;
         uint32_t                  cols;
 
-        uint32_t                  onlyFirstCount;
-        uint32_t                  findRastersCount;
-        uint32_t                  searchCount;
+        uint64_t                  onlyFirstCount;
+        uint64_t                  findRastersCount;
+        uint64_t                  fullSearchCount;
+        uint64_t                  allSamplesCount;
 
         /*--------------------------------------------------------------------
          * Methods
@@ -232,7 +235,7 @@ class GeoIndexedRaster: public RasterObject
         bool            updateCache         (uint32_t& rasters2sample);
         bool            filterRasters       (int64_t gps);
         void            setFindersRange     (void);
-        bool            findAndFilterRasters(OGRGeometry* geo, int64_t gps);
+        bool            _findRasters        (OGRGeometry* geo);
 };
 
 #endif  /* __geo_indexed_raster__ */

--- a/packages/geo/GeoIndexedRaster.h
+++ b/packages/geo/GeoIndexedRaster.h
@@ -55,8 +55,9 @@ class GeoIndexedRaster: public RasterObject
 
         static const int   MAX_CACHE_SIZE     =  20;
         static const int   MAX_READER_THREADS = 200;
-        static const int   MAX_FINDER_THREADS =  16;
-        static const int   MIN_FEATURES_PER_FINDER_THREAD = 10;
+
+        static const int   MAX_FINDER_THREADS;
+        static const int   MIN_FEATURES_PER_FINDER_THREAD;
 
         static const char* FLAGS_TAG;
         static const char* VALUE_TAG;

--- a/packages/geo/GeoIndexedRaster.h
+++ b/packages/geo/GeoIndexedRaster.h
@@ -200,7 +200,7 @@ class GeoIndexedRaster: public RasterObject
         bool                      onlyFirst;
         uint32_t                  numFinders;
         finder_range_t*           findersRange;
-        rasters_group_t           cachedRasterGroup;
+        rasters_group_t           cachedRastersGroup;
         List<finder_t*>           finders;
         List<reader_t*>           readers;
         GdalRaster::overrideCRS_t crscb;
@@ -230,7 +230,7 @@ class GeoIndexedRaster: public RasterObject
         bool            updateCache     (void);
         bool            filterRasters   (int64_t gps);
         void            setFindersRange (void);
-        bool            _findRasters    (OGRGeometry* geo);
+        bool            findAndFilterRasters (OGRGeometry* geo, int64_t gps);
 };
 
 #endif  /* __geo_indexed_raster__ */

--- a/packages/geo/GeoParms.cpp
+++ b/packages/geo/GeoParms.cpp
@@ -55,6 +55,7 @@ const char* GeoParms::START_TIME            = "t0";
 const char* GeoParms::STOP_TIME             = "t1";
 const char* GeoParms::URL_SUBSTRING         = "substr";
 const char* GeoParms::CLOSEST_TIME          = "closest_time";
+const char* GeoParms::SINGLE_STOP           = "single_stop";
 const char* GeoParms::USE_POI_TIME          = "use_poi_time";
 const char* GeoParms::DOY_RANGE             = "doy_range";
 const char* GeoParms::PROJ_PIPELINE         = "proj_pipeline";
@@ -121,6 +122,7 @@ GeoParms::GeoParms (lua_State* L, int index, bool asset_required):
     filter_time         (false),
     url_substring       (NULL),
     filter_closest_time (false),
+    single_stop         (false),
     use_poi_time        (false),
     filter_doy_range    (false),
     doy_keep_inrange    (true),
@@ -234,6 +236,12 @@ GeoParms::GeoParms (lua_State* L, int index, bool asset_required):
                 const TimeLib::date_t closest_date = TimeLib::gmt2date(closest_time);
                 mlog(DEBUG, "Setting %s to %04d-%02d-%02dT%02d:%02d:%02dZ", CLOSEST_TIME, closest_date.year, closest_date.month, closest_date.day, closest_time.hour, closest_time.minute, closest_time.second);
             }
+            lua_pop(L, 1);
+
+            /* Single Stop */
+            lua_getfield(L, index, SINGLE_STOP);
+            single_stop = LuaObject::getLuaBoolean(L, -1, true, single_stop, &field_provided);
+            if(field_provided) mlog(DEBUG, "Setting %s to %d", SINGLE_STOP, (int)single_stop);
             lua_pop(L, 1);
 
             /* Use Point of Interest Time */

--- a/packages/geo/GeoParms.h
+++ b/packages/geo/GeoParms.h
@@ -82,6 +82,7 @@ class GeoParms: public LuaObject
         static const char* STOP_TIME;
         static const char* URL_SUBSTRING;
         static const char* CLOSEST_TIME;
+        static const char* SINGLE_STOP;
         static const char* USE_POI_TIME;
         static const char* DOY_RANGE;
         static const char* PROJ_PIPELINE;
@@ -132,6 +133,7 @@ class GeoParms: public LuaObject
         const char*             url_substring;
         bool                    filter_closest_time;
         TimeLib::gmt_time_t     closest_time;
+        bool                    single_stop;
         bool                    use_poi_time;
         bool                    filter_doy_range;
         bool                    doy_keep_inrange;

--- a/packages/h5/H5Array.h
+++ b/packages/h5/H5Array.h
@@ -161,9 +161,9 @@ bool H5Array<T>::join(int timeout, bool throw_exception)
             /*
              * There is no way to do this in a portable "safe" way. The code
              * below works because our target architectures are x86_64 and aarch64.
-             * The data pointed to by info.data is new'ed and therefore guaranteed
-             * to be aligned to a 16 byte boundary.  The calling code is responsible
-             * for knowing what the data being read out of the h5 file is and
+             * The data pointed to by info.data is new'ed with H5CORO_DATA_ALIGNMENT alignment.
+             * The calling code is responsible for knowing
+             * what the data being read out of the h5 file is and
              * providing the correct type to the template.
              */
             data = reinterpret_cast<T*>(h5f->info.data);

--- a/packages/h5/H5Coro.cpp
+++ b/packages/h5/H5Coro.cpp
@@ -83,7 +83,7 @@ H5Coro::Future::Future (void)
     info.datasize   = 0;
     info.data       = NULL;
     info.datatype   = RecordObject::INVALID_FIELD;
-    
+
     for(int d = 0; d < MAX_NDIMS; d++)
     {
         info.shape[d] = 0;
@@ -99,7 +99,7 @@ H5Coro::Future::Future (void)
 H5Coro::Future::~Future (void)
 {
     wait(IO_PEND);
-    delete [] info.data;
+    operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
 }
 
 /*----------------------------------------------------------------------------
@@ -147,7 +147,7 @@ H5Coro::Future::rc_t H5Coro::Future::wait (int timeout)
  * Constructor
  *  - assumes that asset is in scope for the duration this object is in scope
  *----------------------------------------------------------------------------*/
-H5Coro::Context::Context (Asset* asset, const char* resource):
+H5Coro::Context::Context (const Asset* asset, const char* resource):
     name                (NULL),
     ioDriver            (NULL),
     l1                  (IO_CACHE_L1_ENTRIES, hashL1),
@@ -167,7 +167,7 @@ H5Coro::Context::Context (Asset* asset, const char* resource):
         delete [] name;
         mlog(e.level(), "Failed to create H5 context: %s", e.what());
         throw;
-    }    
+    }
 }
 
 /*----------------------------------------------------------------------------
@@ -469,12 +469,12 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
         if(valtype == RecordObject::INTEGER)
         {
             /* Allocate Buffer of Integers */
-            long* tbuf = new long [info.elements];
+            long* tbuf = new (std::align_val_t(H5CORO_DATA_ALIGNMENT)) long [info.elements];
 
             /* Float to Long */
             if(info.datatype == RecordObject::FLOAT)
             {
-                float* dptr = reinterpret_cast<float*>(info.data);
+                const float* dptr = reinterpret_cast<float*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -483,7 +483,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Double to Long */
             else if(info.datatype == RecordObject::DOUBLE)
             {
-                double* dptr = reinterpret_cast<double*>(info.data);
+                const double* dptr = reinterpret_cast<double*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -492,7 +492,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Char to Long */
             else if(info.datatype == RecordObject::INT8)
             {
-                int8_t* cptr = reinterpret_cast<int8_t*>(info.data);
+                const int8_t* cptr = reinterpret_cast<int8_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(cptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -500,7 +500,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT8)
             {
-                uint8_t* cptr = reinterpret_cast<uint8_t*>(info.data);
+                const uint8_t* cptr = info.data;
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(cptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -527,7 +527,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Short to Long */
             else if(info.datatype == RecordObject::INT16)
             {
-                int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
+                const int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -535,7 +535,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT16)
             {
-                uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
+                const uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -544,7 +544,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Int to Long */
             else if(info.datatype == RecordObject::INT32)
             {
-                int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
+                const int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -552,7 +552,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT32)
             {
-                uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
+                const uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -561,7 +561,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Long to Long */
             else if(info.datatype == RecordObject::INT64)
             {
-                int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
+                const int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -569,7 +569,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT64)
             {
-                uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
+                const uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<long>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -582,20 +582,20 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
 
             /* Switch Buffers */
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = reinterpret_cast<uint8_t*>(tbuf);
             info.datasize = sizeof(long) * info.elements;
         }
         /* Perform Integer Type Transaltion */
         else if(valtype == RecordObject::REAL)
         {
-            /* Allocate Buffer of Integers */
-            double* tbuf = new double [info.elements];
+            /* Allocate Buffer of doubles */
+            double* tbuf = new (std::align_val_t(H5CORO_DATA_ALIGNMENT)) double [info.elements];
 
             /* Float to Double */
             if(info.datatype == RecordObject::FLOAT)
             {
-                float* dptr = reinterpret_cast<float*>(info.data);
+                const float* dptr = reinterpret_cast<float*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]); // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -604,7 +604,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Double to Double */
             else if(info.datatype == RecordObject::DOUBLE)
             {
-                double* dptr = reinterpret_cast<double*>(info.data);
+                const double* dptr = reinterpret_cast<double*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = dptr[i]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -613,7 +613,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Char to Double */
             else if(info.datatype == RecordObject::INT8)
             {
-                int8_t* dptr = reinterpret_cast<int8_t*>(info.data);
+                const int8_t* dptr = reinterpret_cast<int8_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -621,7 +621,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT8)
             {
-                uint8_t* dptr = reinterpret_cast<uint8_t*>(info.data);
+                const uint8_t* dptr = info.data;
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -630,7 +630,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Short to Double */
             else if(info.datatype == RecordObject::INT16)
             {
-                int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
+                const int16_t* dptr = reinterpret_cast<int16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -638,7 +638,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT16)
             {
-                uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
+                const uint16_t* dptr = reinterpret_cast<uint16_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -647,7 +647,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Int to Double */
             else if(info.datatype == RecordObject::INT32)
             {
-                int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
+                const int32_t* dptr = reinterpret_cast<int32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -655,7 +655,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT32)
             {
-                uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
+                const uint32_t* dptr = reinterpret_cast<uint32_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -664,7 +664,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             /* Long to Double */
             else if(info.datatype == RecordObject::INT64)
             {
-                int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
+                const int64_t* dptr = reinterpret_cast<int64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -672,7 +672,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
             else if(info.datatype == RecordObject::UINT64)
             {
-                uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
+                const uint64_t* dptr = reinterpret_cast<uint64_t*>(info.data);
                 for(uint32_t i = 0; i < info.elements; i++)
                 {
                     tbuf[i] = static_cast<double>(dptr[i]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
@@ -685,7 +685,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
             }
 
             /* Switch Buffers */
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = reinterpret_cast<uint8_t*>(tbuf);
             info.datasize = sizeof(double) * info.elements;
         }
@@ -693,7 +693,7 @@ H5Coro::info_t H5Coro::read (Context* context, const char* datasetname, RecordOb
         /* Check Data Valid */
         if(!data_valid)
         {
-            delete [] info.data;
+            operator delete[](info.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
             info.data = NULL;
             info.datasize = 0;
             throw RunTimeException(CRITICAL, RTE_ERROR, "data translation failed for %s: [%d] %d --> %d", datasetname, info.typesize, (int)info.datatype, (int)valtype);

--- a/packages/h5/H5Coro.h
+++ b/packages/h5/H5Coro.h
@@ -70,6 +70,10 @@
 #define H5CORO_ENABLE_FILL false
 #endif
 
+#ifndef H5CORO_DATA_ALIGNMENT
+#define H5CORO_DATA_ALIGNMENT 8
+#endif
+
 /******************************************************************************
  * MACRO
  ******************************************************************************/
@@ -86,7 +90,7 @@ namespace H5Coro
     * Constants
     *--------------------------------------------------------------------*/
 
-    const int MAX_NDIMS = H5CORO_MAXIMUM_DIMENSIONS;    
+    const int MAX_NDIMS = H5CORO_MAXIMUM_DIMENSIONS;
     const long EOR = -1L; // end of range - read rest of the span of a dimension
     const long ALL_ROWS = EOR;
     const long ALL_COLS = EOR;
@@ -99,7 +103,7 @@ namespace H5Coro
         uint32_t                    elements;   // number of elements in dataset
         uint32_t                    typesize;   // number of bytes per element
         uint64_t                    datasize;   // total number of bytes in dataset
-        uint8_t*                    data;       // point to allocated data buffer
+        uint8_t*                    data;       // point to allocated data buffer - must be H5CORO_DATA_ALIGNMENT aligned
         RecordObject::fieldType_t   datatype;   // data type of elements
         int64_t                     shape[MAX_NDIMS]; // dimensions of the data
     } info_t;
@@ -190,7 +194,7 @@ namespace H5Coro
         /* Methods */
         /***********/
 
-                        Context     (Asset* asset, const char* resource);
+                        Context     (const Asset* asset, const char* resource);
                         ~Context    (void);
 
         void            ioRequest   (uint64_t* pos, int64_t size, uint8_t* buffer, int64_t hint, bool cache);

--- a/packages/h5/H5DatasetDevice.cpp
+++ b/packages/h5/H5DatasetDevice.cpp
@@ -184,7 +184,7 @@ bool H5DatasetDevice::isConnected (int num_open)
 void H5DatasetDevice::closeConnection (void)
 {
     connected = false;
-    delete [] dataBuffer;
+    operator delete[](dataBuffer, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     dataBuffer = NULL;
 }
 

--- a/packages/h5/H5Element.h
+++ b/packages/h5/H5Element.h
@@ -90,7 +90,7 @@ H5Element<T>::H5Element(H5Coro::Context* context, const char* variable)
 {
     memset(&value, 0, sizeof(T));
     size = 0;
-    H5Coro::range_t slice[1] = {{0, H5Coro::EOR}};
+    const H5Coro::range_t slice[1] = {{0, H5Coro::EOR}};
     if(context) h5f = H5Coro::readp(context, variable, RecordObject::DYNAMIC, slice, 1);
     else        h5f = NULL;
 }

--- a/packages/h5/H5File.cpp
+++ b/packages/h5/H5File.cpp
@@ -269,7 +269,7 @@ int H5File::luaRead (lua_State* L)
         }
 
         /* Status Complete */
-        mlog(INFO, "Finished reading %d datasets from %s", num_datasets, lua_obj->context->name);
+        mlog(DEBUG, "Finished reading %d datasets from %s", num_datasets, lua_obj->context->name);
 
         /* Terminate Data */
         if(with_terminator)

--- a/packages/h5/H5File.cpp
+++ b/packages/h5/H5File.cpp
@@ -162,7 +162,7 @@ void* H5File::readThread (void* parm)
         }
 
         /* Clean Up Result Data */
-        delete [] results.data;
+        operator delete[](results.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     }
 
     /* Clean Up Thread Info */

--- a/plugins/gebco/plugin/GebcoBathyRaster.cpp
+++ b/plugins/gebco/plugin/GebcoBathyRaster.cpp
@@ -100,7 +100,7 @@ bool GebcoBathyRaster::findRasters(finder_t* finder)
             rasters_group_t* rgroup = new rasters_group_t;
             rgroup->infovect.reserve(1);
             rgroup->id = feature->GetFieldAsString("id");
-            rgroup->gpsTime = getGmtDate(feature, "datetime", rgroup->gmtDate);
+            rgroup->gpsTime = getGmtDate(feature, DATE_TAG, rgroup->gmtDate);
 
             const char* dataFile  = feature->GetFieldAsString("data_raster");
             if(dataFile && (strlen(dataFile) > 0))

--- a/plugins/gebco/plugin/GebcoBathyRaster.cpp
+++ b/plugins/gebco/plugin/GebcoBathyRaster.cpp
@@ -81,11 +81,15 @@ void GebcoBathyRaster::getIndexFile(const OGRGeometry* geo, std::string& file)
 /*----------------------------------------------------------------------------
  * findRasters
  *----------------------------------------------------------------------------*/
-bool GebcoBathyRaster::findRasters(const OGRGeometry* geo)
+bool GebcoBathyRaster::findRasters(finder_t* finder)
 {
+    const OGRGeometry* geo    = finder->geo;
+    const uint32_t start_indx = finder->range.start_indx;
+    const uint32_t end_indx   = finder->range.end_indx;
+
     try
     {
-        for(unsigned i = 0; i < featuresList.size(); i++)
+        for(uint32_t i = start_indx; i < end_indx; i++)
         {
             OGRFeature* feature = featuresList[i];
             OGRGeometry *rastergeo = feature->GetGeometryRef();
@@ -105,6 +109,7 @@ bool GebcoBathyRaster::findRasters(const OGRGeometry* geo)
                 rinfo.dataIsElevation = true;
                 rinfo.tag             = VALUE_TAG;
                 rinfo.fileName        = filePath + "/" + dataFile;
+                rinfo.rasterGeo       = rastergeo->clone();
                 rgroup->infovect.push_back(rinfo);
             }
 
@@ -117,6 +122,7 @@ bool GebcoBathyRaster::findRasters(const OGRGeometry* geo)
                     rinfo.dataIsElevation = false;
                     rinfo.tag = FLAGS_TAG;
                     rinfo.fileName = filePath + "/" + flagsFile;
+                    rinfo.rasterGeo = rastergeo->clone();
                     rgroup->infovect.push_back(rinfo);
                 }
             }
@@ -125,17 +131,17 @@ bool GebcoBathyRaster::findRasters(const OGRGeometry* geo)
             for(unsigned j = 0; j < rgroup->infovect.size(); j++)
                 mlog(DEBUG, "  %s", rgroup->infovect[j].fileName.c_str());
 
-            // Add the group to the groupList
-            groupList.add(groupList.length(), rgroup);
+            // Add the group
+            finder->rasterGroups.push_back(rgroup);
         }
-        mlog(DEBUG, "Found %ld raster groups", groupList.length());
+        mlog(DEBUG, "Found %ld raster groups", finder->rasterGroups.size());
     }
     catch (const RunTimeException &e)
     {
         mlog(e.level(), "Error getting time from raster feature file: %s", e.what());
     }
 
-    return (!groupList.empty());
+    return (!finder->rasterGroups.empty());
 }
 
 

--- a/plugins/gebco/plugin/GebcoBathyRaster.h
+++ b/plugins/gebco/plugin/GebcoBathyRaster.h
@@ -72,7 +72,7 @@ class GebcoBathyRaster: public GeoIndexedRaster
                ~GebcoBathyRaster (void) override;
 
         void    getIndexFile     (const OGRGeometry* geo, std::string& file) final;
-        bool    findRasters      (const OGRGeometry* geo) final;
+        bool    findRasters      (finder_t* finder) final;
 
         /*--------------------------------------------------------------------
          * Data

--- a/plugins/gedi/endpoints/gedi01b.lua
+++ b/plugins/gedi/endpoints/gedi01b.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "gedil1b",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     result_rec      = "gedi01brec",
 }
 

--- a/plugins/gedi/endpoints/gedi02a.lua
+++ b/plugins/gedi/endpoints/gedi02a.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "gedi02a",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     result_rec      = "gedi02arec",
 }
 

--- a/plugins/gedi/endpoints/gedi04a.lua
+++ b/plugins/gedi/endpoints/gedi04a.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "gedi04a",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     result_rec      = "gedi04arec",
 }
 

--- a/plugins/icesat2/endpoints/atl06.lua
+++ b/plugins/icesat2/endpoints/atl06.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "icesat2",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     source_rec      = "atl03rec",
     result_rec      = "atl06rec",
 }

--- a/plugins/icesat2/endpoints/atl08.lua
+++ b/plugins/icesat2/endpoints/atl08.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "icesat2",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     source_rec      = "atl03rec",
     result_rec      = "atl08rec",
 }

--- a/plugins/icesat2/endpoints/atl13s.lua
+++ b/plugins/icesat2/endpoints/atl13s.lua
@@ -12,7 +12,7 @@ local parms         = rqst["parms"]
 local args = {
     shard           = rqst["shard"] or 0, -- key space
     default_asset   = "icesat2",
-    result_q        = parms[geo.PARMS] and "result." .. resource .. "." .. rspq or rspq,
+    result_q        = (parms[geo.PARMS] and not parms[arrow.PARMS]) and "result." .. resource .. "." .. rspq or rspq,
     result_rec      = "atl13srec",
 }
 

--- a/plugins/icesat2/plugin/BathyOceanEyes.cpp
+++ b/plugins/icesat2/plugin/BathyOceanEyes.cpp
@@ -118,7 +118,7 @@ void BathyOceanEyes::init (void)
         {
             /* get uncertainty filename */
             const char* uncertainty_filename = TU_FILENAMES[tu_dimension_index][pointing_angle_index];
-            
+
             /* open csv file */
             fileptr_t file = fopen(uncertainty_filename, "r");
             if(!file)
@@ -170,9 +170,9 @@ void BathyOceanEyes::init (void)
                             coeff_sum.b += tu[i].b;
                             coeff_sum.c += tu[i].c;
                             count += 1.0;
-                        } 
+                        }
                     }
-                    
+
                     /* check count */
                     if(count <= 0)
                     {
@@ -266,7 +266,7 @@ BathyOceanEyes::BathyOceanEyes (lua_State* L, int index):
         /* model as poisson */
         lua_getfield(L, index, OCEANEYES_PARMS_MODEL_AS_POISSON);
         parms.model_as_poisson = LuaObject::getLuaBoolean(L, -1, true, parms.model_as_poisson, NULL);
-        lua_pop(L, 1);        
+        lua_pop(L, 1);
     }
 
     /* Open Kd Resource */
@@ -512,45 +512,45 @@ void BathyOceanEyes::findSeaSurface (extent_t& extent) const
 }
 
 /*----------------------------------------------------------------------------
- * photon_refraction - 
- * 
- * ICESat-2 refraction correction implemented as outlined in Parrish, et al. 
- * 2019 for correcting photon depth data. Reference elevations are to geoid datum 
+ * photon_refraction -
+ *
+ * ICESat-2 refraction correction implemented as outlined in Parrish, et al.
+ * 2019 for correcting photon depth data. Reference elevations are to geoid datum
  * to remove sea surface variations.
- * 
+ *
  * https://www.mdpi.com/2072-4292/11/14/1634
  *
  * ----------------------------------------------------------------------------
  * The code below was adapted from https://github.com/ICESat2-Bathymetry/Information.git
  * with the associated license replicated here:
  * ----------------------------------------------------------------------------
- * 
+ *
  * Copyright (c) 2022, Jonathan Markel/UT Austin.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  *
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
- * Neither the name of the copyright holder nor the names of its 
- * contributors may be used to endorse or promote products derived from this 
- * software without specific prior written permission. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR '
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *----------------------------------------------------------------------------*/
 void BathyOceanEyes::correctRefraction(extent_t& extent) const
@@ -578,7 +578,7 @@ void BathyOceanEyes::correctRefraction(extent_t& extent) const
             const double dZ = p * sin(beta);                            // vertical offset
             const double dY = p * cos(beta);                            // cross-track offset
             const double dE = dY * sin(static_cast<double>(photons[i].ref_az));              // UTM offsets
-            const double dN = dY * cos(static_cast<double>(photons[i].ref_az)); 
+            const double dN = dY * cos(static_cast<double>(photons[i].ref_az));
 
             /* Apply Refraction Corrections */
             photons[i].x_ph += dE;
@@ -598,7 +598,7 @@ void BathyOceanEyes::correctRefraction(extent_t& extent) const
  *----------------------------------------------------------------------------*/
 void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
 {
-    if(extent.photon_count <= 0) return; // nothing to do
+    if(extent.photon_count == 0) return; // nothing to do
 
     /* join kd resource read */
     Kd_490->join(parms.read_timeout_ms, true);
@@ -628,7 +628,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
         /* initialize total uncertainty to aerial uncertainty */
         photons[i].sigma_thu = sqrtf((photons[i].sigma_across * photons[i].sigma_across) + (photons[i].sigma_along * photons[i].sigma_along));
         photons[i].sigma_tvu = photons[i].sigma_h;
-        
+
         /* calculate subaqueous uncertainty */
         const double depth = extent.surface_h - photons[i].ortho_h;
         if(depth > 0.0)
@@ -637,7 +637,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
             int pointing_angle_index = static_cast<int>(roundf(photons[i].pointing_angle));
             if(pointing_angle_index < 0) pointing_angle_index = 0;
             else if(pointing_angle_index >= NUM_POINTING_ANGLES) pointing_angle_index = NUM_POINTING_ANGLES - 1;
-            
+
             /* get wind speed index */
             int wind_speed_index = static_cast<int>(roundf(photons[i].wind_v)) - 1;
             if(wind_speed_index < 0) wind_speed_index = 0;
@@ -645,7 +645,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
 
             /* get kd range index */
             int kd_range_index = 0;
-            while(kd_range_index < NUM_KD_RANGES && KD_RANGES[kd_range_index][1] < kd)
+            while(kd_range_index < (NUM_KD_RANGES-1) && KD_RANGES[kd_range_index][1] < kd)
             {
                 kd_range_index++;
             }
@@ -661,7 +661,7 @@ void BathyOceanEyes::calculateUncertainty (extent_t& extent) const
             /* add subaqueous uncertainties to total uncertainties */
             photons[i].sigma_thu += subaqueous_horizontal_uncertainty;
             photons[i].sigma_tvu += subaqueous_vertical_uncertainty;
-            
+
             /* set maximum sensor depth processing flag */
             if(kd > 0)
             {

--- a/plugins/icesat2/plugin/BathyReader.cpp
+++ b/plugins/icesat2/plugin/BathyReader.cpp
@@ -257,7 +257,7 @@ void BathyReader::init (void)
 /*----------------------------------------------------------------------------
  * Constructor
  *----------------------------------------------------------------------------*/
-BathyReader::BathyReader (lua_State* L, const parms_t* _parms, const char* _resource, 
+BathyReader::BathyReader (lua_State* L, const parms_t* _parms, const char* _resource,
                           const char* outq_name, const char* shared_directory, bool _send_terminator):
     LuaObject(L, OBJECT_TYPE, LUA_META_NAME, LUA_META_TABLE),
     parms(_parms),
@@ -1151,7 +1151,7 @@ void* BathyReader::subsettingThread (void* parm)
 
                 /* Update Statistics */
                 local_stats.photon_count += extent->photon_count;
-                
+
                 /* Export Data */
                 if(parms->return_inputs)
                 {
@@ -1254,7 +1254,7 @@ void* BathyReader::subsettingThread (void* parm)
                         fprintf(out_file, "%d,", extent->photons[i].yapc_score);
                         fprintf(out_file, "%d,", extent->photons[i].max_signal_conf);
                         fprintf(out_file, "%d,", extent->photons[i].quality_ph);
-                        fprintf(out_file, "%d,", extent->photons[i].processing_flags);
+                        fprintf(out_file, "%u,", extent->photons[i].processing_flags);
                         fprintf(out_file, "%d", extent->photons[i].class_ph);
                         fprintf(out_file, "\n");
                     }

--- a/plugins/icesat2/plugin/BathyViewer.cpp
+++ b/plugins/icesat2/plugin/BathyViewer.cpp
@@ -205,7 +205,7 @@ BathyViewer::~BathyViewer (void)
     delete bathyMask;
 
     delete context;
-    
+
     parms->releaseLuaObject();
 
     delete [] resource;
@@ -328,7 +328,7 @@ int BathyViewer::luaCounts (lua_State* L)
 {
     bool status = false;
     int num_obj_to_return = 1;
-    BathyViewer* lua_obj = NULL;
+    const BathyViewer* lua_obj = NULL;
 
     try
     {

--- a/plugins/icesat2/plugin/MeritRaster.cpp
+++ b/plugins/icesat2/plugin/MeritRaster.cpp
@@ -75,7 +75,7 @@ RasterObject* MeritRaster::create(lua_State* L, GeoParms* _parms)
  *----------------------------------------------------------------------------*/
 MeritRaster::~MeritRaster(void)
 {
-    delete [] cache;
+    operator delete[](cache, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     if(asset) asset->releaseLuaObject();
 }
 
@@ -172,7 +172,7 @@ uint32_t MeritRaster::getSamples (const MathLib::point_3d_t& point, int64_t gps,
         if(!value_cached)
         {
             H5Coro::Context context(asset, RESOURCE_NAME);
-            H5Coro::range_t slice[2] = {{0, H5Coro::EOR}, {0, H5Coro::EOR}};
+            const H5Coro::range_t slice[2] = {{0, H5Coro::EOR}, {0, H5Coro::EOR}};
             const H5Coro::info_t info = H5Coro::read(&context, dataset.c_str(), RecordObject::DYNAMIC, slice, 2, false, traceId);
             assert(info.datasize == (X_MAX * Y_MAX * sizeof(int32_t)));
             int32_t* tile = reinterpret_cast<int32_t*>(info.data);
@@ -180,7 +180,7 @@ uint32_t MeritRaster::getSamples (const MathLib::point_3d_t& point, int64_t gps,
             /* Update Cache */
             cacheMut.lock();
             {
-                delete [] cache;
+                operator delete[](cache, std::align_val_t(H5CORO_DATA_ALIGNMENT));
                 cache = tile;
                 cacheLon = left_lon;
                 cacheLat = upper_lat;

--- a/plugins/landsat/plugin/LandsatHlsRaster.cpp
+++ b/plugins/landsat/plugin/LandsatHlsRaster.cpp
@@ -186,7 +186,7 @@ bool LandsatHlsRaster::findRasters(finder_t* finder)
             rasters_group_t* rgroup = new rasters_group_t;
             rgroup->infovect.reserve(MAX_LANDSAT_RASTER_GROUP_SIZE);
             rgroup->id = feature->GetFieldAsString("id");
-            rgroup->gpsTime = getGmtDate(feature, "datetime", rgroup->gmtDate);
+            rgroup->gpsTime = getGmtDate(feature, DATE_TAG, rgroup->gmtDate);
 
             /* Find each requested band in the index file */
             bool val;

--- a/plugins/landsat/plugin/LandsatHlsRaster.h
+++ b/plugins/landsat/plugin/LandsatHlsRaster.h
@@ -83,7 +83,7 @@ class LandsatHlsRaster: public GeoIndexedRaster
                ~LandsatHlsRaster (void) override;
 
         void    getIndexFile     (const OGRGeometry* geo, std::string& file) final;
-        bool    findRasters      (const OGRGeometry* geo) override;
+        bool    findRasters      (finder_t* finder) final;
         void    getGroupSamples  (const rasters_group_t* rgroup, List<RasterSample*>& slist, uint32_t flags) final;
 
 
@@ -102,6 +102,7 @@ class LandsatHlsRaster: public GeoIndexedRaster
 
         std::string filePath;
         std::string indexFile;
+        Mutex bandsDictMutex;
         Dictionary<bool> bandsDict;
 
         bool ndsi;

--- a/plugins/landsat/selftests/landsat_reader.lua
+++ b/plugins/landsat/selftests/landsat_reader.lua
@@ -300,7 +300,7 @@ print(string.format("\n-------------------------------------------------\nLandsa
 dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0,
                             bands = {"VAA", "VZA", "Fmask","SAA", "SZA", "NDSI", "NDVI", "NDWI",
                                      "B01", "B02", "B03", "B04", "B05", "B06",
-                                     "B07", "B08", "B09", "B10", "B11", "B12", "B8A", },
+                                     "B07", "B08", "B09", "B10", "B11", "B12", "B8A"},
                             catalog = contents }))
 
 sampleCnt = 0
@@ -321,6 +321,33 @@ end
 runner.check(sampleCnt == 180)
 print(string.format("POI sample time: %.2f   (%d threads)", stoptime - starttime, sampleCnt))
 
+
+print(string.format("\n-------------------------------------------------\nLandsat POI OnlyFirst test\n-------------------------------------------------"))
+dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, single_stop = true,
+                            bands = {"VAA", "VZA", "Fmask","SAA", "SZA", "NDSI", "NDVI", "NDWI",
+                                     "B01", "B02", "B03", "B04", "B05", "B06",
+                                     "B07", "B08", "B09", "B10", "B11", "B12", "B8A"},
+                            catalog = contents }))
+
+sampleCnt = 0
+local starttime = time.latch();
+tbl, err = dem:sample(lon, lat, height)
+local stoptime = time.latch();
+if err ~= 0 then
+    print(string.format("======> FAILED to read", lon, lat))
+else
+    local value, fname
+    for j, v in ipairs(tbl) do
+        value = v["value"]
+        fname = v["file"]
+        sampleCnt = sampleCnt + 1
+        print(string.format("(%02d) value %10.3f, fname: %s", j, value, fname))
+    end
+end
+-- OnlyFirst should return 20 samples/rasters, not 180 (all bands given in parameters minues "Fmask")
+runner.check(sampleCnt == 20)
+print(string.format("POI OnlyFirst sample time: %.2f   (%d threads)", stoptime - starttime, sampleCnt))
+
 print(string.format("\n-------------------------------------------------\nLandsat AOI Subset test\n-------------------------------------------------"))
 
 -- AOI extent (extent of hls_trimmed.geojson)
@@ -329,6 +356,12 @@ lly =    50.45
 urx =  -178.27
 ury =    51.44
 
+
+dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0,
+                            bands = {"VAA", "VZA", "Fmask","SAA", "SZA", "NDSI", "NDVI", "NDWI",
+                                     "B01", "B02", "B03", "B04", "B05", "B06",
+                                     "B07", "B08", "B09", "B10", "B11", "B12", "B8A"},
+                            catalog = contents }))
 
 local starttime = time.latch();
 local tbl, err = dem:subset(llx, lly, urx, ury)

--- a/plugins/pgc/plugin/PgcDemStripsRaster.h
+++ b/plugins/pgc/plugin/PgcDemStripsRaster.h
@@ -52,6 +52,7 @@ class PgcDemStripsRaster: public GeoIndexedRaster
 
                  PgcDemStripsRaster (lua_State* L, GeoParms* _parms, const char* dem_name, const char* geo_suffix, GdalRaster::overrideCRS_t cb);
                 ~PgcDemStripsRaster (void) override;
+        bool     getFeatureDate     (const OGRFeature* feature, TimeLib::gmt_time_t& gmtDate) final;
         bool     openGeoIndex       (const OGRGeometry* geo) final;
         void     getIndexFile       (const OGRGeometry* geo, std::string& file) final;
         bool     findRasters        (finder_t* finder) final;

--- a/plugins/pgc/plugin/PgcDemStripsRaster.h
+++ b/plugins/pgc/plugin/PgcDemStripsRaster.h
@@ -54,7 +54,7 @@ class PgcDemStripsRaster: public GeoIndexedRaster
                 ~PgcDemStripsRaster (void) override;
         bool     openGeoIndex       (const OGRGeometry* geo) final;
         void     getIndexFile       (const OGRGeometry* geo, std::string& file) final;
-        bool     findRasters        (const OGRGeometry* geo) final;
+        bool     findRasters        (finder_t* finder) final;
 
     private:
         void    _getIndexFile       (double lon, double lat, std::string& file);

--- a/plugins/pgc/selftests/only_first_test.lua
+++ b/plugins/pgc/selftests/only_first_test.lua
@@ -1,0 +1,66 @@
+local runner = require("test_executive")
+local console = require("console")
+local asset = require("asset")
+local csv = require("csv")
+local json = require("json")
+
+-- console.monitor:config(core.LOG, core.DEBUG)
+-- sys.setlvl(core.LOG, core.DEBUG)
+
+local assets = asset.loaddir()
+
+-- Unit Test For Temporal filter --
+
+local sigma = 1.0e-9
+
+local lon = -178.0
+local lat =   51.7
+local height = 0
+
+local demType = "arcticdem-strips"
+
+-- With single_stop = false, sample call returns multiple rasters (14)
+-- With single_stop = true, sample call returns only the first raster
+
+local expResults = {{452.48437500, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV01_20181210_102001007A560E00_10200100802C2300_2m_lsf_seg3_dem.tif'},
+                    {632.90625000, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV01_20200222_1020010099A56800_1020010095159800_2m_lsf_seg1_dem.tif'},
+                    { 81.50000000, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV01_20210127_10200100A0B3CA00_10200100A2906A00_2m_lsf_seg1_dem.tif'},
+                    { 80.65625000, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV01_20210303_10200100A47BBC00_10200100A64F5900_2m_lsf_seg1_dem.tif'},
+                    { 82.89843750, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV01_20210605_10200100B27E2100_10200100B2D61C00_2m_lsf_seg1_dem.tif'},
+                    {773.03906250, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20140226_103001002D248E00_103001002E2D7D00_2m_lsf_seg1_dem.tif'},
+                    { 80.22656250, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20160602_1030010057849C00_103001005607CA00_2m_lsf_seg1_dem.tif'},
+                    { 83.57031250, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20170916_103001006F1E7900_10300100701E7200_2m_lsf_seg1_dem.tif'},
+                    { 85.17187500, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20181220_103001008ABD1400_103001008A640D00_2m_lsf_seg1_dem.tif'},
+                    { 83.91406250, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20200225_10300100A18EF500_10300100A32D9C00_2m_lsf_seg2_dem.tif'},
+                    { 81.21093750, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20200326_10300100A60E3900_10300100A4BA7E00_2m_lsf_seg1_dem.tif'},
+                    {117.30468750, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV02_20210223_10300100B2CBC000_10300100B642EA00_2m_lsf_seg1_dem.tif'},
+                    { 79.74218750, 0x0, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV03_20190906_104001005146B800_1040010051638000_2m_lsf_seg1_dem.tif'},
+                    { 49.92187500, 0x4, '/vsis3/pgc-opendata-dems/arcticdem/strips/s2s041/2m/n51w178/SETSM_s2s041_WV03_20210204_10400100656B9F00_1040010065903500_2m_lsf_seg1_dem.tif'}}
+
+
+print(string.format("\n--------------------------------\nTest: %s OnlyFirst\n--------------------------------", demType))
+local dem = geo.raster(geo.parms({asset=demType, algorithm="NearestNeighbour", single_stop = true, radius=0, with_flags=true}))
+tbl, err = dem:sample(lon, lat, height)
+runner.check(err == 0)
+runner.check(tbl ~= nil)
+
+sampleCnt = 0
+for i, v in ipairs(tbl) do
+    local el = v["value"]
+    local fname = v["file"]
+    local flags = v["flags"]
+    print(string.format("(%02d) %16.8fm  qmask: 0x%x %s", i, el, flags, fname))
+    sampleCnt = sampleCnt + 1
+
+    runner.check(math.abs(el - expResults[i][1]) < sigma)
+    runner.check(flags == expResults[i][2])
+    runner.check(fname == expResults[i][3])
+end
+runner.check(sampleCnt == 1)
+dem=nil
+
+
+-- Report Results --
+
+runner.report()
+

--- a/plugins/pgc/systests/arcticdem_strips_perf.lua
+++ b/plugins/pgc/systests/arcticdem_strips_perf.lua
@@ -19,8 +19,12 @@ local  height = 0
 local _lon = lon
 local _lat = lat
 
+local t0str = "2000:2:25:23:00:00"
+local t1str = "2024:6:2:24:00:00"
+
 print(string.format("\n------------------------------------\nStrips reading one point\n------------------------------------"))
 local dem = geo.raster(geo.parms({asset="arcticdem-strips", algorithm="NearestNeighbour", radius=0}))
+-- local dem = geo.raster(geo.parms({asset="arcticdem-strips", algorithm="NearestNeighbour", radius=0, t0=t0str, t1=t1str}))
 local starttime = time.latch();
 local tbl, err = dem:sample(lon, lat, height)
 local stoptime = time.latch();

--- a/plugins/swot/plugin/SwotL2Reader.cpp
+++ b/plugins/swot/plugin/SwotL2Reader.cpp
@@ -146,7 +146,7 @@ SwotL2Reader::SwotL2Reader (lua_State* L, Asset* _asset, const char* _resource, 
     threadCount = 0;
 
     try
-    {  
+    {
         /* Create H5Coro Context */
         context = new H5Coro::Context(asset, resource);
 
@@ -194,7 +194,7 @@ SwotL2Reader::SwotL2Reader (lua_State* L, Asset* _asset, const char* _resource, 
             /* Terminate */
             checkComplete();
         }
-    }       
+    }
     catch(const RunTimeException& e)
     {
         mlog(CRITICAL, "Failed to create SWOT reader");
@@ -464,7 +464,7 @@ void* SwotL2Reader::varThread (void* parm)
     try
     {
         /* Read Dataset */
-        H5Coro::range_t slice[2] = {{reader->region->first_line, reader->region->first_line + reader->region->num_lines}, {0, H5Coro::EOR}};
+        const H5Coro::range_t slice[2] = {{reader->region->first_line, reader->region->first_line + reader->region->num_lines}, {0, H5Coro::EOR}};
         results = H5Coro::read(reader->context, info->variable_name, RecordObject::DYNAMIC, slice, 2, false, trace_id);
 
         /* Post Results to Output Queue */
@@ -521,7 +521,7 @@ void* SwotL2Reader::varThread (void* parm)
     reader->checkComplete();
 
     /* Clean Up */
-    delete [] results.data;
+    operator delete[](results.data, std::align_val_t(H5CORO_DATA_ALIGNMENT));
     delete [] info->variable_name;
     delete info;
 

--- a/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.cpp
+++ b/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.cpp
@@ -114,7 +114,7 @@ bool Usgs3dep1meterDemRaster::findRasters(finder_t* finder)
             rasters_group_t* rgroup = new rasters_group_t;
             rgroup->infovect.reserve(1);
             rgroup->id = feature->GetFieldAsString("id");
-            rgroup->gpsTime = getGmtDate(feature, "datetime", rgroup->gmtDate);
+            rgroup->gpsTime = getGmtDate(feature, DATE_TAG, rgroup->gmtDate);
 
             const char* fname = feature->GetFieldAsString("url");
             if(fname && strlen(fname) > 0)

--- a/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.h
+++ b/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.h
@@ -88,6 +88,10 @@ class Usgs3dep1meterDemRaster: public GeoIndexedRaster
          *--------------------------------------------------------------------*/
         std::string filePath;
         std::string indexFile;
+
+        OGRGeometry* cachedGeo;
+        rasters_group_t cachedRasterGroup;
+        bool onlyFirst;
 };
 
 #endif  /* __usgs3dep_1meter_dem_raster__ */

--- a/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.h
+++ b/plugins/usgs3dep/plugin/Usgs3dep1meterDemRaster.h
@@ -73,7 +73,7 @@ class Usgs3dep1meterDemRaster: public GeoIndexedRaster
                ~Usgs3dep1meterDemRaster (void) override;
 
         void    getIndexFile     (const OGRGeometry* geo, std::string& file) final;
-        bool    findRasters      (const OGRGeometry* geo) final;
+        bool    findRasters      (finder_t* finder) final;
 
         static OGRErr overrideTargetCRS(OGRSpatialReference& target);
 
@@ -88,10 +88,6 @@ class Usgs3dep1meterDemRaster: public GeoIndexedRaster
          *--------------------------------------------------------------------*/
         std::string filePath;
         std::string indexFile;
-
-        OGRGeometry* cachedGeo;
-        rasters_group_t cachedRasterGroup;
-        bool onlyFirst;
 };
 
 #endif  /* __usgs3dep_1meter_dem_raster__ */

--- a/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
+++ b/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
@@ -12,14 +12,14 @@ local json = require("json")
 local assets = asset.loaddir()
 
 local _,td = runner.srcscript()
-local geojsonfile = td.."../data/grand_mesa_1m_dem.geojson"
+local geojsonfile = td.."../data/wrzesien_mountain_snow_sieve_catalog.geojson"
 local f = io.open(geojsonfile, "r")
 local contents = f:read("*all")
 f:close()
 
 
 local _,td = runner.srcscript()
-local poifile = td.."../../landsat/data/grand_mesa_poi.txt"
+local poifile = td.."../data/wrzesien_snow_poi.txt"
 local f = io.open(poifile, "r")
 -- read in array of POI from file
 local arr = {}
@@ -39,11 +39,11 @@ for i=1, 10 do
 end
 ]]
 
-print(string.format("\n-------------------------------------------------\nusgs3dep 1meter DEM Grand Mesa test\n-------------------------------------------------"))
+print(string.format("\n-------------------------------------------------\nusgs3dep 1meter DEM wrzesien mountain snow test\n-------------------------------------------------"))
 
 local demType = "usgs3dep-1meter-dem"
-local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, catalog = contents }))
--- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, catalog = contents }))
+-- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, catalog = contents }))
+local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, catalog = contents }))
 
 local failedRead = 0
 local samplesCnt = 0
@@ -52,14 +52,14 @@ local errorChecking = true
 local starttime = time.latch();
 
 -- for i=1,#arr do
-for i=1, 10000 do
+for i=1,  50000 do
     local  lon = arr[i][1]
     local  lat = arr[i][2]
     local  height = 0
     local  tbl, err = dem:sample(lon, lat, height)
     if err ~= 0 then
         failedRead = failedRead + 1
-        print(string.format("======> FAILED to read", lon, lat))
+        -- print(string.format("======> FAILED to read", lon, lat))
     else
         local value, fname, time
         for j, v in ipairs(tbl) do

--- a/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
+++ b/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
@@ -39,11 +39,19 @@ for i=1, 10 do
 end
 ]]
 
+local t0str = "2022:10:1:0:00:00"
+local t1str = "2023:9:30:24:00:00"
+
+
 print(string.format("\n-------------------------------------------------\nusgs3dep 1meter DEM wrzesien mountain snow test\n-------------------------------------------------"))
 
 local demType = "usgs3dep-1meter-dem"
+
 -- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, catalog = contents }))
-local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, catalog = contents }))
+-- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, t0=t0str, t1=t1str, catalog = contents }))
+
+-- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, catalog = contents }))
+local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, t0=t0str, t1=t1str, catalog = contents }))
 
 local failedRead = 0
 local samplesCnt = 0

--- a/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
+++ b/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
@@ -39,8 +39,8 @@ for i=1, 10 do
 end
 ]]
 
-local t0str = "2022:10:1:0:00:00"
-local t1str = "2023:9:30:24:00:00"
+local t0str = "2022:10:01:00:00:00"
+local t1str = "2023:09:30:23:59:59"
 
 
 print(string.format("\n-------------------------------------------------\nusgs3dep 1meter DEM wrzesien mountain snow test\n-------------------------------------------------"))
@@ -59,8 +59,8 @@ local errorChecking = true
 
 local starttime = time.latch();
 
--- for i=1,#arr do
-for i=1,  50000 do
+for i=1,#arr do
+-- for i=1,  50000 do
     local  lon = arr[i][1]
     local  lat = arr[i][2]
     local  height = 0

--- a/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
+++ b/plugins/usgs3dep/systests/wrzesien_mountain_snow_test.lua
@@ -11,15 +11,13 @@ local json = require("json")
 
 local assets = asset.loaddir()
 
-local _,td = runner.srcscript()
-local geojsonfile = td.."../data/wrzesien_mountain_snow_sieve_catalog.geojson"
+local geojsonfile = "/data/3dep/wrzesien_mountain_snow_sieve_catalog.geojson"
 local f = io.open(geojsonfile, "r")
 local contents = f:read("*all")
 f:close()
 
 
-local _,td = runner.srcscript()
-local poifile = td.."../data/wrzesien_snow_poi.txt"
+local poifile = "/data/3dep/wrzesien_snow_poi.txt"
 local f = io.open(poifile, "r")
 -- read in array of POI from file
 local arr = {}
@@ -48,10 +46,10 @@ print(string.format("\n-------------------------------------------------\nusgs3d
 local demType = "usgs3dep-1meter-dem"
 
 -- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, catalog = contents }))
--- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, t0=t0str, t1=t1str, catalog = contents }))
+local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", radius = 0, t0=t0str, t1=t1str, catalog = contents }))
 
 -- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, catalog = contents }))
-local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, t0=t0str, t1=t1str, catalog = contents }))
+-- local dem = geo.raster(geo.parms({ asset = demType, algorithm = "NearestNeighbour", single_stop = true, radius = 0, t0=t0str, t1=t1str, catalog = contents }))
 
 local failedRead = 0
 local samplesCnt = 0
@@ -60,7 +58,6 @@ local errorChecking = true
 local starttime = time.latch();
 
 for i=1,#arr do
--- for i=1,  50000 do
     local  lon = arr[i][1]
     local  lat = arr[i][2]
     local  height = 0
@@ -91,7 +88,7 @@ end
 local stoptime = time.latch();
 local dtime = stoptime - starttime
 
-print(string.format("\nSamples: %d, failedRead: %d", samplesCnt, failedRead))
+print(string.format("Samples: %d, failedRead: %d", samplesCnt, failedRead))
 print(string.format("ExecTime: %f", dtime))
 
 sys.quit(0)

--- a/plugins/usgs3dep/utils/wrzesien_mountain_snow_test_setup.ipynb
+++ b/plugins/usgs3dep/utils/wrzesien_mountain_snow_test_setup.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e496cdcc-a029-44d4-90f9-94e7686d5d9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a273c7e1-f3e0-4221-924c-110b4c7942be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sliderule\n",
+    "from sliderule import gedi, earthdata, raster, icesat2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e2dbede-3951-4186-bfff-9259142e5e67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sliderule.init(\"localhost\", organization=None, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bd96c60-a1f6-4a6c-b2c8-793d9825f91f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poly_geojson = '/data/3dep/wrzesien_mountain_snow_sieve_poly.geojson'\n",
+    "bbox_gdf = gpd.read_file(poly_geojson)\n",
+    "bbox_gdf.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea5b9900-1264-47d9-b922-76984cae8ebb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bbox_gdf_simple = bbox_gdf.copy()\n",
+    "bbox_gdf_simple['geometry'] = bbox_gdf_simple.simplify(tolerance=0.01)\n",
+    "bbox_gdf_simple = bbox_gdf_simple.dissolve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a4de264-a6ec-441e-9a14-53934b46da1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = sliderule.toregion(bbox_gdf_simple, cellsize=0.01)\n",
+    "region['gdf'].plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba04d952-a961-46a2-97ba-58c0f9aa3f5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year = 2022\n",
+    "t0 = f'{year}-10-01T00:00:00Z'\n",
+    "t1 = f'{year+1}-09-30T23:59:59Z'\n",
+    "time_start = f'{year}-10-01'\n",
+    "time_end = f'{year+1}-09-30'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b78b7a6e-604f-4915-8487-820a2515dc9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "catalog_file = '/data/3dep/wrzesien_mountain_snow_sieve_catalog.geojson'\n",
+    "\n",
+    "earthdata.set_max_resources(999999)\n",
+    "\n",
+    "if not os.path.exists(catalog_file):\n",
+    "    # usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', time_start=time_start, time_end=time_end, polygon=region['poly'])\n",
+    "    usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', time_start=t0, time_end=t1, polygon=region['poly'])\n",
+    "\n",
+    "    # Save usgs3dep_catalog to a file\n",
+    "    with open(catalog_file, 'w') as file:\n",
+    "        file.write(usgs3dep_catalog)\n",
+    "else:\n",
+    "    with open(catalog_file, 'r') as file:\n",
+    "        usgs3dep_catalog = file.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8379c91-ae08-4ff9-9993-a5633f5b39ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "d = json.loads(usgs3dep_catalog)\n",
+    "len(d['features'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4452c6a0-70b6-4b5f-afab-5342c9c80968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d['features'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92ff223b-7abb-487e-9226-db49c12cc096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parquet_file = '/data/3dep/wrzesien_snow.parquet'\n",
+    "poi_file     = '/data/3dep/wrzesien_snow_poi.txt'\n",
+    "\n",
+    "is2_parms = {\n",
+    "    \"asset\": \"icesat2\",\n",
+    "    \"poly\": region['poly'],\n",
+    "    \"raster\": region['raster'],\n",
+    "    \"max_resources\": 999999,\n",
+    "    \"timeout\": 6000,\n",
+    "    \"srt\": 0,\n",
+    "    \"len\": 40,\n",
+    "    \"res\": 20,\n",
+    "    \"cnf\": 4,\n",
+    "    \"atl08_class\": [\"atl08_ground\"],\n",
+    "    \"maxi\": 6,\n",
+    "    \"ats\": 20.0,\n",
+    "    \"cnt\": 10,\n",
+    "    \"H_min_win\": 3.0,\n",
+    "    \"sigma_r_max\": 5.0,\n",
+    "    # \"output\": {\"path\": parquet_file, \"format\": \"parquet\", \"as_geo\": True, \"open_on_complete\": True},\n",
+    "    \"samples\": {\"3dep\": {\"asset\": \"usgs3dep-1meter-dem\", \"use_poi_time\": True, \"catalog\": usgs3dep_catalog, \"single_stop\": True, \"t0\": t0, \"t1\": t1}},\n",
+    "    # \"samples\": {\"3dep\": {\"asset\": \"usgs3dep-1meter-dem\", \"use_poi_time\": True, \"catalog\": usgs3dep_catalog, \"single_stop\": False, \"t0\": t0, \"t1\": t1}},\n",
+    "    \"t0\":t0, \"t1\":t1   #This if for temporal filtering of ATL08 granules\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93d2950f-698b-49a5-9a1a-2fb2699f157b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "resources = earthdata.search(is2_parms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b7ab928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "is2_ground = icesat2.atl06p(is2_parms, height_key='h_mean', resources=resources[:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a154439",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generate_poi = False\n",
+    "\n",
+    "if generate_poi and os.path.exists(parquet_file):\n",
+    "    gdf = gpd.read_parquet(parquet_file)\n",
+    "    print(gdf.columns)\n",
+    "\n",
+    "    # Ensure the geometry column is in the correct format (Point)\n",
+    "    if not gdf.geometry.geom_type.isin(['Point']).all():\n",
+    "        raise ValueError(\"All geometries must be of Point type\")\n",
+    "\n",
+    "    # Open the output file and write the coordinates\n",
+    "    with open(poi_file, mode='w') as txt_file:\n",
+    "        for index, row in gdf.iterrows():\n",
+    "            # Extract longitude and latitude from the geometry column\n",
+    "            longitude = row.geometry.x\n",
+    "            latitude = row.geometry.y\n",
+    "            txt_file.write(f\"{longitude} {latitude}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "363e7134-392f-4387-bf8f-140c01e59961",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#is2_ground"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ce88f24-eb00-4f41-9ce7-85c3f83e30f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is2_ground['d'] = is2_ground['3dep.value'].notna()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d917178-d833-4f66-b6a1-a947654724ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is2_ground['d'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f62051ff-fe72-416c-ac47-96bfcd7b81b4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/project-config.cmake
+++ b/project-config.cmake
@@ -126,6 +126,8 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         "--suppress=unreadVariable:*/TimeLib.cpp"                       # line: 471, terminating '\0' detected as 'unused' but it is used/needed
         "--suppress=invalidPointerCast:*/H5Array.h"                     # line: 166, documented in code
         "--suppress=invalidPointerCast:*/H5Element.h"                   # line: 141, documented in code
+        "--suppress=invalidPointerCast:*/H5Coro.cpp"                    # info.data is newed on 8 byte boundries, can supress this warning
+        "--suppress=uninitvar:*/H5Coro.cpp"                             # info
         "--suppress=copyCtorPointerCopying:*/MsgQ.cpp"                  # line: 120, shallow copy which is fine in code
         "--error-exitcode=1"
 
@@ -136,6 +138,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         "--suppress=constParameterReference:*/ArrowBuilderImpl.cpp"     # List [] const issue
         "--suppress=constParameterPointer:*/CcsdsPayloadDispatch.cpp"   # Not trivial to fix, would have to change DispachObject class as well.
         "--suppress=knownConditionTrueFalse"                            # -1 < 0 etc
+        "--suppress=constParameterReference:*/BathyOceanEyes.cpp"       # extent_t& extent cannot be const
     )
 
 endif()

--- a/scripts/extensions/georesource.lua
+++ b/scripts/extensions/georesource.lua
@@ -36,7 +36,7 @@ local function initialize(resource, parms, algo, args)
 
     -- Raster Sampler --
     local sampler_disp = nil
-    if parms[geo.PARMS] then
+    if parms[geo.PARMS] and not parms[arrow.PARMS] then
         local rsps_bridge = core.bridge(args.result_q, rspq)
         sampler_disp = core.dispatcher(args.result_q, 1) -- 1 thread required due to performance issues for GeoIndexRasters
         for key,settings in pairs(parms[geo.PARMS]) do

--- a/scripts/selftests/parquet_sampler.lua
+++ b/scripts/selftests/parquet_sampler.lua
@@ -51,7 +51,7 @@ runner.check(parquet_sampler ~= nil)
 local in_file_size = getFileSize(in_geoparquet);
 print("Input  geoparquet file size: " .. in_file_size .. " bytes")
 
-local status = parquet_sampler:sample()
+local status = parquet_sampler:waiton()
 local out_file_size = getFileSize(_out_geoparquet);
 print("Output geoparquet file size: " .. out_file_size .. " bytes")
 runner.check(out_file_size > in_file_size, "Output file size is not greater than input file size: ")
@@ -63,7 +63,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_parquet);
 print("Input  parquet file size: "  .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_parquet);
 print("Output parquet file size: " .. out_file_size .. " bytes")
 runner.check(out_file_size > in_file_size, "Output file size is not greater than input file size: ")
@@ -77,7 +77,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_geoparquet);
 print("Input geoparquet file size: "  .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_feather);
 print("Output parquet file size:    " .. out_file_size .. " bytes")
 runner.check(out_file_size < in_file_size, "Output file size is not smaller than input file size: ")
@@ -94,7 +94,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_parquet);
 print("Input geoparquet file size: "  .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_feather);
 print("Output parquet file size:    " .. out_file_size .. " bytes")
 runner.check(out_file_size < in_file_size, "Output file size is not smaller than input file size: ")
@@ -111,7 +111,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_geoparquet);
 print("Input geoparquet file size: " .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_csv);
 print("Output CSV file size:        " .. out_file_size .. " bytes")
 runner.check(out_file_size < in_file_size, "Output CSV file size is not smaller than input file size: ")
@@ -128,7 +128,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_parquet);
 print("Input parquet file size: "  .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_csv);
 print("Output CSV file size:     " .. out_file_size .. " bytes")
 runner.check(out_file_size < in_file_size, "Output CSV file size is not smaller than input file size: ")
@@ -145,7 +145,7 @@ runner.check(parquet_sampler ~= nil)
 in_file_size = getFileSize(in_geoparquet);
 print("Input  geoparquet file size: " .. in_file_size .. " bytes")
 
-status = parquet_sampler:sample()
+status = parquet_sampler:waiton()
 out_file_size = getFileSize(_out_geoparquet);
 print("Output geoparquet file size: " .. out_file_size .. " bytes")
 runner.check(out_file_size > in_file_size, "Output file size is not greater than input file size: ")

--- a/scripts/selftests/test_runner.lua
+++ b/scripts/selftests/test_runner.lua
@@ -92,6 +92,7 @@ if __pgc__ and incloud then
     runner.script(pgc_td .. "plugin_unittest.lua")
     runner.script(pgc_td .. "arcticdem_reader.lua")
     runner.script(pgc_td .. "temporal_filter_test.lua")
+    runner.script(pgc_td .. "only_first_test.lua")
     runner.script(pgc_td .. "url_filter_test.lua")
     runner.script(pgc_td .. "zonal_stats_test.lua")
     runner.script(pgc_td .. "resampling_test.lua")


### PR DESCRIPTION
__Updates__:

* added a "single_stop" parameter to geo parms where the raster sampling code will stop have the first found raster; since this is implemented in the `find_rasters` function which is virtual, this option is only implemented in the 3dep plugin.

* added code tot he 3dep plugin per above -> if the single_stop option is selected then it caches the raster group that was found and checks it first the next time through

* changed the ArrowSampler class to kick off a thread to do the sampling right from the constructor

__Benchmark__:

Running 1 granule through David's notebook that has 63885 points of interest and samples 3DEP that has 23076 rasters, here are the timings I get - 

| Output | SingleStop w/ Caching | MultiStop w/o Caching |
| --- | --- | --- |
| Parquet (ArrowSampler) | 12 min, 13 sec | 18 min, 5 sec |
| Stream (RasterSampler) | 11 min, 20 sec | 15 min, 35 sec |

Note: the "SingleStop w/ Caching" option bypassed the linear feature search for each point of interest about 85% of the time