### PR TITLE
Fast parquet sampler

### DIFF
--- a/packages/arrow/ArrowSampler.h
+++ b/packages/arrow/ArrowSampler.h
@@ -100,6 +100,7 @@ class ArrowSampler: public LuaObject
 
             explicit BatchSampler (const char* _rkey, RasterObject* _robj, ArrowSampler* _obj);
                     ~BatchSampler (void);
+             void    clearSamples (void);
         } batch_sampler_t;
 
         typedef struct
@@ -166,6 +167,8 @@ class ArrowSampler: public LuaObject
         static void*    mainThread       (void* parm);
         static void     batchSampling    (batch_sampler_t* sampler);
         static void*    readerThread     (void* parm);
+        static void*    readSamples      (RasterObject* robj, uint32_t start_indx, uint32_t end_indx,
+                                          ArrowSampler* obj, std::vector<ArrowSampler::sample_list_t*>& samples);
 };
 
 #endif  /* __parquet_sampler__*/

--- a/packages/arrow/ArrowSamplerImpl.cpp
+++ b/packages/arrow/ArrowSamplerImpl.cpp
@@ -108,7 +108,7 @@ void ArrowSamplerImpl::processInputFile(const char* file_path, std::vector<Arrow
 /*----------------------------------------------------------------------------
 * processSamples
 *----------------------------------------------------------------------------*/
-bool ArrowSamplerImpl::processSamples(ArrowSampler::sampler_t* sampler)
+bool ArrowSamplerImpl::processSamples(ArrowSampler::batch_sampler_t* sampler)
 {
     const ArrowParms* parms = arrowSampler->getParms();
     bool  status = false;
@@ -300,7 +300,7 @@ void ArrowSamplerImpl::getXYPoints(std::vector<ArrowSampler::point_info_t*>& poi
         ArrowSampler::point_info_t* pinfo = new ArrowSampler::point_info_t({x, y, 0.0});
         points.push_back(pinfo);
     }
-    mlog(INFO, "Read %ld points from file", points.size());
+    mlog(DEBUG, "Read %ld points from file", points.size());
 }
 
 /*----------------------------------------------------------------------------
@@ -413,7 +413,7 @@ std::shared_ptr<arrow::Table> ArrowSamplerImpl::addNewColumns(const std::shared_
 /*----------------------------------------------------------------------------
 * makeColumnsWithLists
 *----------------------------------------------------------------------------*/
-bool ArrowSamplerImpl::makeColumnsWithLists(ArrowSampler::sampler_t* sampler)
+bool ArrowSamplerImpl::makeColumnsWithLists(ArrowSampler::batch_sampler_t* sampler)
 {
     auto* pool = arrow::default_memory_pool();
     RasterObject* robj = sampler->robj;
@@ -596,7 +596,7 @@ bool ArrowSamplerImpl::makeColumnsWithLists(ArrowSampler::sampler_t* sampler)
 /*----------------------------------------------------------------------------
 * makeColumnsWithOneSample
 *----------------------------------------------------------------------------*/
-bool ArrowSamplerImpl::makeColumnsWithOneSample(ArrowSampler::sampler_t* sampler)
+bool ArrowSamplerImpl::makeColumnsWithOneSample(ArrowSampler::batch_sampler_t* sampler)
 {
     auto* pool = arrow::default_memory_pool();
     RasterObject* robj = sampler->robj;
@@ -933,8 +933,8 @@ std::string ArrowSamplerImpl::createFileMap(void)
     rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
 
     /* Serialize into JSON */
-    const std::vector<ArrowSampler::sampler_t*>& samplers = arrowSampler->getSamplers();
-    for(ArrowSampler::sampler_t* sampler : samplers)
+    const std::vector<ArrowSampler::batch_sampler_t*>& samplers = arrowSampler->getBatchSamplers();
+    for(ArrowSampler::batch_sampler_t* sampler : samplers)
     {
         rapidjson::Value asset_list_json(rapidjson::kArrayType);
 

--- a/packages/arrow/ArrowSamplerImpl.h
+++ b/packages/arrow/ArrowSamplerImpl.h
@@ -64,7 +64,7 @@ class ArrowSamplerImpl
         ~ArrowSamplerImpl         (void);
 
         void processInputFile     (const char* file_path, std::vector<ArrowSampler::point_info_t*>& points);
-        bool processSamples       (ArrowSampler::sampler_t* sampler);
+        bool processSamples       (ArrowSampler::batch_sampler_t* sampler);
         void createOutpuFiles     (void);
 
     private:
@@ -104,8 +104,8 @@ class ArrowSamplerImpl
         void                          getGeoPoints            (std::vector<ArrowSampler::point_info_t*>& points);
         std::shared_ptr<arrow::Table> inputFileToTable        (const std::vector<const char*>& columnNames = {});
         std::shared_ptr<arrow::Table> addNewColumns           (const std::shared_ptr<arrow::Table>& table);
-        bool                          makeColumnsWithLists    (ArrowSampler::sampler_t* sampler);
-        bool                          makeColumnsWithOneSample(ArrowSampler::sampler_t* sampler);
+        bool                          makeColumnsWithLists    (ArrowSampler::batch_sampler_t* sampler);
+        bool                          makeColumnsWithOneSample(ArrowSampler::batch_sampler_t* sampler);
         static RasterSample*          getFirstValidSample     (ArrowSampler::sample_list_t* slist);
         static void                   tableToParquet          (const std::shared_ptr<arrow::Table>& table,
                                                                const char* file_path);

--- a/packages/geo/GeoIndexedRaster.cpp
+++ b/packages/geo/GeoIndexedRaster.cpp
@@ -234,7 +234,7 @@ uint32_t GeoIndexedRaster::getSubsets(const MathLib::extent_t& extent, int64_t g
  *----------------------------------------------------------------------------*/
 GeoIndexedRaster::~GeoIndexedRaster(void)
 {
-    mlog(INFO, "onlyFirst: %lu, fullSearch: %lu, findRastersCalls: %lu, allSamples: %lu",
+    mlog(DEBUG, "onlyFirst: %lu, fullSearch: %lu, findRastersCalls: %lu, allSamples: %lu",
                 onlyFirstCount, fullSearchCount, findRastersCount, allSamplesCount);
 
     delete [] findersRange;
@@ -490,7 +490,7 @@ bool GeoIndexedRaster::openGeoIndex(const OGRGeometry* geo)
         }
 
         GDALClose((GDALDatasetH)dset);
-        mlog(INFO, "Loaded %lu raster index file", featuresList.size());
+        mlog(DEBUG, "Loaded %lu raster index file", featuresList.size());
     }
     catch (const RunTimeException &e)
     {

--- a/packages/geo/RasterObject.h
+++ b/packages/geo/RasterObject.h
@@ -77,10 +77,12 @@ class RasterObject: public LuaObject
         static void          deinit          (void);
         static int           luaCreate       (lua_State* L);
         static RasterObject* cppCreate       (GeoParms* _parms);
+        static RasterObject* cppCreate       (const RasterObject* obj);
         static bool          registerRaster  (const char* _name, factory_f create);
         virtual uint32_t     getSamples      (const MathLib::point_3d_t& point, int64_t gps, List<RasterSample*>& slist, void* param=NULL) = 0;
         virtual uint32_t     getSubsets      (const MathLib::extent_t&  extent, int64_t gps, List<RasterSubset*>& slist, void* param=NULL) = 0;
         virtual uint8_t*     getPixels       (uint32_t ulx, uint32_t uly, uint32_t xsize=0, uint32_t ysize=0, void* param=NULL);
+        virtual uint32_t     getMaxBatchThreads(void);
                             ~RasterObject    (void) override;
 
         bool hasZonalStats (void)
@@ -103,6 +105,9 @@ class RasterObject: public LuaObject
             return fileDict;
         }
 
+        uint64_t    fileDictAdd     (const std::string& fileName);
+        const char* fileDictGetFile (uint64_t fileId);
+
     protected:
 
         /*--------------------------------------------------------------------
@@ -110,7 +115,6 @@ class RasterObject: public LuaObject
          *--------------------------------------------------------------------*/
 
                     RasterObject    (lua_State* L, GeoParms* _parms);
-        uint64_t    fileDictAdd     (const std::string& fileName);
         static int  luaSamples      (lua_State* L);
         static int  luaSubsets      (lua_State* L);
         static int  luaPixels       (lua_State *L);

--- a/packages/geo/RasterSample.h
+++ b/packages/geo/RasterSample.h
@@ -77,6 +77,15 @@ public:
           .mad = 0.0}
     {
     }
+
+    std::string toString(void) const
+    {
+        char buffer[1024];
+        snprintf(buffer, sizeof(buffer), "time: %.2lf, value: %.2lf, verticalShift: %.2lf, fileId: %lu, flags: %u, stats: {count: %u, min: %.2lf, max: %.2lf, mean: %.2lf, median: %.2lf, stdev: %.2lf, mad: %.2lf}",
+            time, value, verticalShift, fileId, flags, stats.count, stats.min, stats.max, stats.mean, stats.median, stats.stdev, stats.mad);
+        return std::string(buffer);
+    }
+
 };
 
 #endif  /* __raster_sample__ */

--- a/plugins/landsat/plugin/LandsatHlsRaster.cpp
+++ b/plugins/landsat/plugin/LandsatHlsRaster.cpp
@@ -348,6 +348,18 @@ void LandsatHlsRaster::getGroupSamples (const rasters_group_t* rgroup, List<Rast
 
 
 
+/*----------------------------------------------------------------------------
+ * getMaxBatchThreads
+ *----------------------------------------------------------------------------*/
+uint32_t LandsatHlsRaster::getMaxBatchThreads(void)
+{
+    /*
+     * The average number of strips for a point is ~10
+     * Limit the number of batch threads to 8.
+     */
+    return 8;
+}
+
 
 
 /******************************************************************************

--- a/plugins/landsat/plugin/LandsatHlsRaster.h
+++ b/plugins/landsat/plugin/LandsatHlsRaster.h
@@ -79,12 +79,13 @@ class LandsatHlsRaster: public GeoIndexedRaster
          * Methods
          *--------------------------------------------------------------------*/
 
-                LandsatHlsRaster (lua_State* L, GeoParms* _parms);
-               ~LandsatHlsRaster (void) override;
+                 LandsatHlsRaster   (lua_State* L, GeoParms* _parms);
+                ~LandsatHlsRaster   (void) override;
 
-        void    getIndexFile     (const OGRGeometry* geo, std::string& file) final;
-        bool    findRasters      (finder_t* finder) final;
-        void    getGroupSamples  (const rasters_group_t* rgroup, List<RasterSample*>& slist, uint32_t flags) final;
+        void     getIndexFile       (const OGRGeometry* geo, std::string& file) final;
+        bool     findRasters        (finder_t* finder) final;
+        void     getGroupSamples    (const rasters_group_t* rgroup, List<RasterSample*>& slist, uint32_t flags) final;
+        uint32_t getMaxBatchThreads (void) final;
 
 
     private:

--- a/plugins/pgc/plugin/PgcDemStripsRaster.cpp
+++ b/plugins/pgc/plugin/PgcDemStripsRaster.cpp
@@ -190,6 +190,19 @@ void PgcDemStripsRaster::getIndexFile(const OGRGeometry* geo, std::string& file)
 }
 
 /*----------------------------------------------------------------------------
+ * getMaxBatchThreads
+ *----------------------------------------------------------------------------*/
+uint32_t PgcDemStripsRaster::getMaxBatchThreads(void)
+{
+    /*
+     * The average number of strips for a point is between 10 to 20.
+     * There are areas where the number of strips can be over 100.
+     * Limit the number of batch threads to 1.
+     */
+    return 1;
+}
+
+/*----------------------------------------------------------------------------
  * findRasters
  *----------------------------------------------------------------------------*/
 bool PgcDemStripsRaster::findRasters(finder_t* finder)

--- a/plugins/pgc/plugin/PgcDemStripsRaster.h
+++ b/plugins/pgc/plugin/PgcDemStripsRaster.h
@@ -56,6 +56,7 @@ class PgcDemStripsRaster: public GeoIndexedRaster
         bool     openGeoIndex       (const OGRGeometry* geo) final;
         void     getIndexFile       (const OGRGeometry* geo, std::string& file) final;
         bool     findRasters        (finder_t* finder) final;
+        uint32_t getMaxBatchThreads (void) final;
 
     private:
         void    _getIndexFile       (double lon, double lat, std::string& file);

--- a/plugins/usgs3dep/utils/wrzesien_mountain_snow_test_setup.ipynb
+++ b/plugins/usgs3dep/utils/wrzesien_mountain_snow_test_setup.ipynb
@@ -98,7 +98,8 @@
     "\n",
     "if not os.path.exists(catalog_file):\n",
     "    # usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', time_start=time_start, time_end=time_end, polygon=region['poly'])\n",
-    "    usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', time_start=t0, time_end=t1, polygon=region['poly'])\n",
+    "    # usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', time_start=t0, time_end=t1, polygon=region['poly'])\n",
+    "    usgs3dep_catalog = earthdata.tnm(short_name='Digital Elevation Model (DEM) 1 meter', polygon=region['poly'])\n",
     "\n",
     "    # Save usgs3dep_catalog to a file\n",
     "    with open(catalog_file, 'w') as file:\n",
@@ -156,10 +157,11 @@
     "    \"cnt\": 10,\n",
     "    \"H_min_win\": 3.0,\n",
     "    \"sigma_r_max\": 5.0,\n",
+    "    \"output\": {\"path\": \"/data/3dep/wrzesien_snow.parquet\", \"format\": \"parquet\", \"as_geo\": True, \"open_on_complete\": True},\n",
     "    # \"output\": {\"path\": parquet_file, \"format\": \"parquet\", \"as_geo\": True, \"open_on_complete\": True},\n",
-    "    \"samples\": {\"3dep\": {\"asset\": \"usgs3dep-1meter-dem\", \"use_poi_time\": True, \"catalog\": usgs3dep_catalog, \"single_stop\": True, \"t0\": t0, \"t1\": t1}},\n",
+    "    # \"samples\": {\"3dep\": {\"asset\": \"usgs3dep-1meter-dem\", \"use_poi_time\": True, \"catalog\": usgs3dep_catalog, \"single_stop\": True, \"t0\": t0, \"t1\": t1}},\n",
     "    # \"samples\": {\"3dep\": {\"asset\": \"usgs3dep-1meter-dem\", \"use_poi_time\": True, \"catalog\": usgs3dep_catalog, \"single_stop\": False, \"t0\": t0, \"t1\": t1}},\n",
-    "    \"t0\":t0, \"t1\":t1   #This if for temporal filtering of ATL08 granules\n",
+    "    \"t0\":t0, \"t1\":t1   #This is for temporal filtering of ATL08 granules\n",
     "}"
    ]
   },
@@ -192,7 +194,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generate_poi = False\n",
+    "# generate_poi = False\n",
+    "generate_poi = True\n",
     "\n",
     "if generate_poi and os.path.exists(parquet_file):\n",
     "    gdf = gpd.read_parquet(parquet_file)\n",

--- a/scripts/systests/parquet_sampler_perf_test.lua
+++ b/scripts/systests/parquet_sampler_perf_test.lua
@@ -1,0 +1,70 @@
+local runner = require("test_executive")
+console = require("console")
+asset = require("asset")
+local assets = asset.loaddir()
+local td = runner.rootdir(arg[0])
+
+local outq_name = "outq-luatest"
+
+local in_parquet = '/data/3dep/wrzesien_snow.parquet'
+
+-- Indicates local file system (no s3 or client)
+local prefix = "file://"
+
+local _out_parquet   = "/data/3dep/output/wrzesien_snow_samples.parquet"
+local out_parquet    = prefix .. _out_parquet
+
+local geojsonfile = "/data/3dep/wrzesien_mountain_snow_sieve_catalog.geojson"
+local f = io.open(geojsonfile, "r")
+local contents = f:read("*all")
+f:close()
+
+
+-- console.monitor:config(core.LOG, core.DEBUG)
+-- sys.setlvl(core.LOG, core.DEBUG)
+
+function getFileSize(filePath)
+    local file = io.open(filePath, "rb")  -- 'rb' mode opens the file in binary mode
+    if not file then
+        print("Could not open file: " .. filePath .. " for reading\n")
+        return nil
+    end
+    local fileSize = file:seek("end")  -- Go to the end of the file
+    file:close()  -- Close the file
+    return fileSize
+end
+
+local robj_3dep = geo.raster(geo.parms({asset="usgs3dep-1meter-dem", algorithm="NearestNeighbour", radius=0, catalog = contents, use_poi_time=true}))
+runner.check(robj_3dep ~= nil)
+
+print('\n--------------------------------------\nTest01: input/output parquet (x, y)\n--------------------------------------')
+local starttime = time.latch();
+parquet_sampler = arrow.sampler(arrow.parms({path=out_parquet, format="parquet"}), in_parquet, outq_name, {["3dep"] = robj_3dep})
+-- parquet_sampler = arrow.sampler(arrow.parms({path=out_parquet, format="parquet"}), in_parquet, outq_name, {["mosaic"] = robj_arcticdem})
+-- parquet_sampler = arrow.sampler(arrow.parms({path=out_parquet, format="parquet"}), in_parquet, outq_name, {["3dep"] = robj_3dep, ["mosaic"] = robj_arcticdem})
+runner.check(parquet_sampler ~= nil)
+status = parquet_sampler:waiton()
+local stoptime = time.latch();
+local dtime = stoptime - starttime
+
+print(string.format("ExecTime: %f", dtime))
+
+
+in_file_size = getFileSize(in_parquet);
+print("Input  parquet file size: "  .. in_file_size .. " bytes")
+
+status = parquet_sampler:waiton()
+out_file_size = getFileSize(_out_parquet);
+print("Output parquet file size: " .. out_file_size .. " bytes")
+runner.check(out_file_size > in_file_size, "Output file size is not greater than input file size: ")
+
+-- There is no easy way to read parquet file in Lua, check the size of the output files
+-- the files were tested with python scripts
+
+-- Remove the output files
+-- os.remove(_out_parquet)
+
+-- Report Results --
+
+runner.report()
+

--- a/scripts/systests/parquet_sampler_perf_test.lua
+++ b/scripts/systests/parquet_sampler_perf_test.lua
@@ -35,6 +35,7 @@ function getFileSize(filePath)
 end
 
 local robj_3dep = geo.raster(geo.parms({asset="usgs3dep-1meter-dem", algorithm="NearestNeighbour", radius=0, catalog = contents, use_poi_time=true}))
+-- local robj_3dep = geo.raster(geo.parms({asset="usgs3dep-1meter-dem", algorithm="NearestNeighbour", radius=0, catalog = contents, use_poi_time=true, single_stop=true, }))
 runner.check(robj_3dep ~= nil)
 
 print('\n--------------------------------------\nTest01: input/output parquet (x, y)\n--------------------------------------')


### PR DESCRIPTION
I implemented batch sampling using multiple threads in the parquet sampler code.

**Performance Results:**
**Old Code**: Using a single thread and a single 3DEP raster object for all points took 12 minutes.
**Parallel Sampling:** Utilizing 16 threads, each with its own 3DEP raster object to sample an assigned subset of points, reduced the time to approximately 2.5 minutes across multiple runs.

Note: The 'firstOnly' option with caching was not used because use_poi_time=true. These two options are mutually exclusive. In runs where 'firstOnly' was used, the time dropped to just over a minute. However, this option is not viable if we need to use point time from the parquet file.