### PR TITLE
NISAR L2 GOFF support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ option (USE_PGC_DATASET "Include the PGC dataset" ON)
 option (USE_SWOT_DATASET "Include the SWOT dataset" ON)
 option (USE_USGS3DEP_DATASET "Include the USGS 3DEP dataset" ON)
 option (USE_GEDTM_DATASET "Include the GEDTM dataset" ON)
+option (USE_NISAR_DATASET "Include the NISAR dataset" ON)
 
 # Target Options #
 
@@ -387,6 +388,10 @@ endif()
 
 if(${USE_GEDTM_DATASET})
     add_subdirectory (datasets/gedtm)
+endif()
+
+if(${USE_NISAR_DATASET})
+    add_subdirectory (datasets/nisar)
 endif()
 
 # Targets #

--- a/datasets/nisar/CMakeLists.txt
+++ b/datasets/nisar/CMakeLists.txt
@@ -1,0 +1,23 @@
+message (STATUS "Including nisar dataset")
+
+target_compile_definitions (slideruleLib PUBLIC __nisar__)
+
+target_sources(slideruleLib
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/package/nisar.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/package/NisarDataset.cpp
+)
+
+target_include_directories (slideruleLib
+    PUBLIC
+        $<INSTALL_INTERFACE:${INCDIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/package
+)
+
+install (
+    FILES
+        ${CMAKE_CURRENT_LIST_DIR}/package/nisar.h
+        ${CMAKE_CURRENT_LIST_DIR}/package/NisarDataset.h
+    DESTINATION
+        ${INCDIR}/nisar
+)

--- a/datasets/nisar/data/nisar_fake.geojson
+++ b/datasets/nisar/data/nisar_fake.geojson
@@ -1,0 +1,27 @@
+{
+  "_comment1": "This is a fake query result, when CMR supports NISAR replace it with an actual CMR query result",
+  "_comment2": "The Polygon is the bounding box from the h5 file used here, the h5 file is from NISAR samples, the rest is made up",
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "nisar-goff-001",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-118.460221357625, 34.235748204922],
+            [-117.480816711884, 34.235748204922],
+            [-117.480816711884, 35.3645719098044],
+            [-118.460221357625, 35.3645719098044],
+            [-118.460221357625, 34.235748204922]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2008-11-04T06:09:42.000000+00:00",
+        "url": "https://sds-n-cumulus-prod-nisar-sample-data.s3.us-west-2.amazonaws.com/GOFF/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001.h5"
+      }
+    }
+  ]
+}

--- a/datasets/nisar/nisar.md
+++ b/datasets/nisar/nisar.md
@@ -1,0 +1,1 @@
+HDF5 data sets sampling support for NISAR selected L2 and L3 products.

--- a/datasets/nisar/package/NisarDataset.cpp
+++ b/datasets/nisar/package/NisarDataset.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2021, University of Washington
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the University of Washington nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY OF WASHINGTON AND CONTRIBUTORS
+ * “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF WASHINGTON OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/******************************************************************************
+ * INCLUDES
+ ******************************************************************************/
+
+#include "NisarDataset.h"
+
+/* Valid Bands for BlueTopo Bathy Raster */
+const char* NisarDataset::validBands[] = {"azimuthOffset", "rangeOffset"};  // For now we only support these
+#define validBandsCnt (sizeof (validBands) / sizeof (const char *))
+
+/******************************************************************************
+ * PROTECTED METHODS
+ ******************************************************************************/
+
+/*----------------------------------------------------------------------------
+ * Constructor
+ *----------------------------------------------------------------------------*/
+NisarDataset::NisarDataset(lua_State* L, RequestFields* rqst_parms, const char* key):
+ GeoIndexedRaster(L, rqst_parms, key),
+ filePath(parms->asset.asset->getPath()),
+ indexFile("/vsimem/" + GdalRaster::getUUID() + ".geojson")
+{
+    if(!validateBandNames())
+    {
+        throw RunTimeException(DEBUG, RTE_FAILURE, "Invalid band name specified");
+    }
+
+    /* Create in memory index file (geojson) */
+    VSILFILE* fp = VSIFileFromMemBuffer(indexFile.c_str(),
+                                        const_cast<GByte*>(reinterpret_cast<const GByte*>(parms->catalog.value.c_str())), // source bytes
+                                        static_cast<vsi_l_offset>(parms->catalog.value.size()), // length in bytes
+                                        FALSE);
+    CHECKPTR(fp);
+    VSIFCloseL(fp);
+}
+
+/*----------------------------------------------------------------------------
+ * Destructor
+ *----------------------------------------------------------------------------*/
+NisarDataset::~NisarDataset(void)
+{
+    VSIUnlink(indexFile.c_str());
+}
+
+/*----------------------------------------------------------------------------
+ * getIndexFile
+ *----------------------------------------------------------------------------*/
+void NisarDataset::getIndexFile(const OGRGeometry* geo, std::string& file)
+{
+    static_cast<void>(geo);
+    file = indexFile;
+    mlog(DEBUG, "Using %s", file.c_str());
+}
+
+/*----------------------------------------------------------------------------
+ * getIndexFile
+ *----------------------------------------------------------------------------*/
+void NisarDataset::getIndexFile(const std::vector<point_info_t>* points, std::string& file)
+{
+    static_cast<void>(points);
+    file = indexFile;
+    mlog(DEBUG, "Using %s", file.c_str());
+}
+
+/*----------------------------------------------------------------------------
+ * findRasters
+ *----------------------------------------------------------------------------*/
+bool NisarDataset::findRasters(raster_finder_t* finder)
+{
+    static_cast<void>(finder);
+
+    const std::string h5file = "/vsis3/sds-n-cumulus-prod-nisar-sample-data/GOFF/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001.h5";
+    // const std::string h5file = "/data/NISAR/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001.h5"
+    // const std::string ds1 = "HDF5:\"" + h5file + "\"" + "://science/LSAR/GCOV/metadata/radarGrid/alongTrackUnitVectorX";
+    // const std::string ds2 = "HDF5:\"" + h5file + "\"" + "://science/LSAR/GCOV/metadata/radarGrid/alongTrackUnitVectorY";
+
+    const std::string ds1 = R"(HDF5:"/vsis3/sds-n-cumulus-prod-nisar-sample-data/GOFF/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001/NISAR_L2_PR_GOFF_001_030_A_019_002_2000_SH_20081012T060911_20081012T060925_20081127T061000_20081127T061014_D00404_N_F_J_001.h5"://science/LSAR/GOFF/grids/frequencyA/pixelOffsets/HH/layer1/alongTrackOffset)";
+    const std::vector<std::string> datasets = {ds1};
+
+    try
+    {
+        for(uint32_t i = 0; i < datasets.size(); i++)
+        {
+            rasters_group_t* rgroup = new rasters_group_t;
+            // rgroup->gpsTime = getGmtDate(feature, "Delivered_Date", rgroup->gmtDate) / 1000.0;
+
+            const std::string& fullPath = datasets[i];
+
+            raster_info_t rinfo;
+            rinfo.elevationBandNum = 0;
+            rinfo.tag = VALUE_TAG;
+            rinfo.fileId = finder->fileDict.add(fullPath);
+            rgroup->infovect.push_back(rinfo);
+            rgroup->infovect.shrink_to_fit();
+
+            mlog(DEBUG, "Added group with %ld rasters", rgroup->infovect.size());
+            for(unsigned j = 0; j < rgroup->infovect.size(); j++)
+                mlog(DEBUG, "  %s", finder->fileDict.get(rgroup->infovect[j].fileId));
+
+            // Add the group
+            finder->rasterGroups.push_back(rgroup);
+        }
+        finder->rasterGroups.shrink_to_fit();
+
+        mlog(DEBUG, "Found %ld raster groups", finder->rasterGroups.size());
+    }
+    catch (const RunTimeException &e)
+    {
+        mlog(e.level(), "Error getting time from raster feature file: %s", e.what());
+    }
+
+    return (!finder->rasterGroups.empty());
+}
+
+
+/*----------------------------------------------------------------------------
+ * getGmtDate
+ *----------------------------------------------------------------------------*/
+double NisarDataset::getGmtDate(const OGRFeature* feature, const char* field, TimeLib::gmt_time_t& gmtDate)
+{
+    const int i = feature->GetFieldIndex(field);
+    if(i == -1)
+    {
+        mlog(ERROR, "Time field: %s not found, unable to get GMT date", field);
+        return 0;
+    }
+
+    double gpstime = 0;
+    double seconds;
+    int year;
+    int month;
+    int day;
+    int hour;
+    int minute;
+
+    /*
+    * The raster's 'Delivered_Date' in the GPKG index file is not in ISO8601 format.
+    * Instead, it uses the format "YYYY-MM-DD HH:MM:SS".
+    */
+    if(const char* dateStr = feature->GetFieldAsString(i))
+    {
+        if(sscanf(dateStr, "%04d-%02d-%02d %02d:%02d:%lf",
+            &year, &month, &day, &hour, &minute, &seconds) == 6)
+        {
+            gmtDate.year = year;
+            gmtDate.doy = TimeLib::dayofyear(year, month, day);
+            gmtDate.hour = hour;
+            gmtDate.minute = minute;
+            gmtDate.second = seconds;
+            gmtDate.millisecond = 0;
+            gpstime = TimeLib::gmt2gpstime(gmtDate);
+            // mlog(DEBUG, "%04d:%02d:%02d:%02d:%02d:%02d", year, month, day, hour, minute, (int)seconds);
+        }
+        else mlog(DEBUG, "Unable to parse date string [%s]", dateStr);
+    }
+    else mlog(DEBUG, "Date field is invalid");
+
+    return gpstime;
+}
+
+
+/******************************************************************************
+ * PRIVATE METHODS
+ ******************************************************************************/
+
+/*----------------------------------------------------------------------------
+ * validateBandNames
+ *----------------------------------------------------------------------------*/
+bool NisarDataset::validateBandNames(void)
+{
+    if(parms->bands.length() == 0)
+    {
+        mlog(ERROR, "No bands specified");
+        return false;
+    }
+
+    for (int i = 0; i < parms->bands.length(); i++)
+    {
+        bool valid = false;
+        for(size_t j = 0; j < validBandsCnt; j++)
+        {
+            /* Raster band names are case insensitive */
+            if(strcmp(parms->bands[i].c_str(), validBands[j]) == 0)
+            {
+                valid = true;
+                break;
+            }
+        }
+
+        if(!valid)
+        {
+            mlog(ERROR, "Invalid band name: %s", parms->bands[i].c_str());
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/datasets/nisar/package/NisarDataset.cpp
+++ b/datasets/nisar/package/NisarDataset.cpp
@@ -190,24 +190,11 @@ void NisarDataset::getSerialGroupSamples(const rasters_group_t* rgroup, List<Ras
  *----------------------------------------------------------------------------*/
 uint32_t NisarDataset::getBatchGroupSamples(const rasters_group_t* rgroup, List<RasterSample*>* slist, uint32_t flags, uint32_t pointIndx)
 {
+    // TODO: implement
+    static_cast<void>(rgroup);
+    static_cast<void>(slist);
+    static_cast<void>(flags);
     static_cast<void>(pointIndx);
-
-    //TODO: for L2 GEOFF we will be processing all 3 layers of datasets, for now return them all
-    for(const auto& rinfo : rgroup->infovect)
-    {
-        const char* key = fileDictGet(rinfo.fileId);
-        cacheitem_t* item;
-        if(cache.find(key, &item) && !item->bandSample.empty())
-        {
-            RasterSample* sample = new RasterSample(*item->bandSample[0]);
-
-            /* sample can be NULL if raster read failed, (e.g. point out of bounds) */
-            if(sample == NULL) continue;
-
-            sample->flags = flags;
-            slist->add(sample);
-        }
-    }
 
     return SS_NO_ERRORS;
 }

--- a/datasets/nisar/package/NisarDataset.h
+++ b/datasets/nisar/package/NisarDataset.h
@@ -29,8 +29,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __bluetopo_bathy_raster__
-#define __bluetopo_bathy_raster__
+#ifndef __nisar_dataset__
+#define __nisar_dataset__
 
 /******************************************************************************
  * INCLUDES
@@ -39,10 +39,10 @@
 #include "GeoIndexedRaster.h"
 
 /******************************************************************************
- * GEBCO BATHY RASTER CLASS
+ * NISAR DATASET CLASS
  ******************************************************************************/
 
-class BlueTopoBathyRaster: public GeoIndexedRaster
+class NisarDataset: public GeoIndexedRaster
 {
     public:
 
@@ -60,7 +60,7 @@ class BlueTopoBathyRaster: public GeoIndexedRaster
          *--------------------------------------------------------------------*/
 
         static RasterObject* create(lua_State* L, RequestFields* rqst_parms, const char* key)
-                          { return new BlueTopoBathyRaster(L, rqst_parms, key); }
+                          { return new NisarDataset(L, rqst_parms, key); }
 
 
     protected:
@@ -70,8 +70,8 @@ class BlueTopoBathyRaster: public GeoIndexedRaster
          *--------------------------------------------------------------------*/
         double  getGmtDate (const OGRFeature* feature, const char* field,  TimeLib::gmt_time_t& gmtDate) final;
 
-                BlueTopoBathyRaster (lua_State* L, RequestFields* rqst_parms, const char* key);
-               ~BlueTopoBathyRaster (void) override;
+                NisarDataset (lua_State* L, RequestFields* rqst_parms, const char* key);
+               ~NisarDataset (void) override;
 
         void    getIndexFile (const OGRGeometry* geo, std::string& file) final;
         void    getIndexFile (const std::vector<point_info_t>* points, std::string& file) final;
@@ -88,14 +88,12 @@ class BlueTopoBathyRaster: public GeoIndexedRaster
          *--------------------------------------------------------------------*/
 
         bool validateBandNames (void);
-        bool findIndexFileInS3Bucket (const std::string& bucketPath);
 
         /*--------------------------------------------------------------------
          * Data
          *--------------------------------------------------------------------*/
         std::string filePath;
-        std::string indexBucket;
         std::string indexFile;
 };
 
-#endif  /* __bluetopo_bathy_raster__ */
+#endif  /* __nisar_dataset__ */

--- a/datasets/nisar/package/NisarDataset.h
+++ b/datasets/nisar/package/NisarDataset.h
@@ -37,6 +37,7 @@
  ******************************************************************************/
 
 #include "GeoIndexedRaster.h"
+#include <unordered_map>
 
 /******************************************************************************
  * NISAR DATASET CLASS
@@ -49,7 +50,9 @@ class NisarDataset: public GeoIndexedRaster
         /*--------------------------------------------------------------------
          * Constants
          *--------------------------------------------------------------------*/
-        static const char* validBands[];
+        static const char* validL2GOFFbands[];
+        static const char* URL_str;
+
 
         /*--------------------------------------------------------------------
          * Typedefs
@@ -68,14 +71,18 @@ class NisarDataset: public GeoIndexedRaster
         /*--------------------------------------------------------------------
          * Methods
          *--------------------------------------------------------------------*/
-        double  getGmtDate (const OGRFeature* feature, const char* field,  TimeLib::gmt_time_t& gmtDate) final;
-
                 NisarDataset (lua_State* L, RequestFields* rqst_parms, const char* key);
                ~NisarDataset (void) override;
 
         void    getIndexFile (const OGRGeometry* geo, std::string& file) final;
         void    getIndexFile (const std::vector<point_info_t>* points, std::string& file) final;
         bool    findRasters  (raster_finder_t* finder) final;
+
+        void    getSerialGroupSamples(const rasters_group_t* rgroup, List<RasterSample*>& slist, uint32_t flags) final;
+        uint32_t getBatchGroupSamples(const rasters_group_t* rgroup, List<RasterSample*>* slist, uint32_t flags, uint32_t pointIndx) final;
+
+        static CPLErr overrideGeoTransform (double* gtf, const void* param);
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL);
 
         /*--------------------------------------------------------------------
          * Data
@@ -87,13 +94,18 @@ class NisarDataset: public GeoIndexedRaster
          * Methods
          *--------------------------------------------------------------------*/
 
-        bool validateBandNames (void);
+        bool validateL2GOFFbandNames (void);
 
         /*--------------------------------------------------------------------
          * Data
          *--------------------------------------------------------------------*/
         std::string filePath;
         std::string indexFile;
+
+        static Mutex transfMutex;
+        static Mutex crsMutex;
+        static std::unordered_map<std::string, std::array<double, 6>> transformCache;
+        static std::unordered_map<std::string, int> crsCache;
 };
 
 #endif  /* __nisar_dataset__ */

--- a/datasets/nisar/package/nisar.cpp
+++ b/datasets/nisar/package/nisar.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, University of Washington
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the University of Washington nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY OF WASHINGTON AND CONTRIBUTORS
+ * “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF WASHINGTON OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/******************************************************************************
+ *INCLUDES
+ ******************************************************************************/
+
+#include "OsApi.h"
+#include "nisar.h"
+
+/******************************************************************************
+ * DEFINES
+ ******************************************************************************/
+
+#define LUA_NISAR_LIBNAME         "nisar"
+#define LUA_NISAR_L2_DATASET_NAME "nisar-L2-geoff"
+
+/******************************************************************************
+ * LOCAL FUNCTIONS
+ ******************************************************************************/
+
+/*----------------------------------------------------------------------------
+ * bluetopo_open
+ *----------------------------------------------------------------------------*/
+int nisar_open (lua_State *L)
+{
+    static const struct luaL_Reg nisar_functions[] = {
+        {NULL, NULL}
+    };
+
+    /* Set Library */
+    luaL_newlib(L, nisar_functions);
+
+    return 1;
+}
+
+/******************************************************************************
+ * EXPORTED FUNCTIONS
+ ******************************************************************************/
+
+extern "C" {
+void initnisar(void)
+{
+    /* Initialize Modules */
+    NisarDataset::init();
+
+    /* Register Rasters */
+    RasterObject::registerRaster(LUA_NISAR_L2_DATASET_NAME, NisarDataset::create);
+
+    /* Extend Lua */
+    LuaEngine::extend(LUA_NISAR_LIBNAME, nisar_open);
+
+    /* Indicate Presence of Package */
+    LuaEngine::indicate(LUA_NISAR_LIBNAME, LIBID);
+
+    /* Display Status */
+    print2term("%s package initialized (%s)\n", LUA_NISAR_LIBNAME, LIBID);
+}
+
+void deinitnisar(void)
+{
+    /* Uninitialize Modules */
+    NisarDataset::deinit();
+}
+}

--- a/datasets/nisar/package/nisar.h
+++ b/datasets/nisar/package/nisar.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, University of Washington
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the University of Washington nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY OF WASHINGTON AND CONTRIBUTORS
+ * “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE UNIVERSITY OF WASHINGTON OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __nisar_plugin__
+#define __nisar_plugin__
+
+/******************************************************************************
+ * INCLUDES
+ ******************************************************************************/
+
+#include "NisarDataset.h"
+
+/******************************************************************************
+ * PROTOTYPES
+ ******************************************************************************/
+
+extern "C" {
+void initnisar(void);
+void deinitnisar(void);
+}
+
+#endif  /* __nisar_plugin__ */
+
+

--- a/datasets/nisar/selftests/nisar_reader.lua
+++ b/datasets/nisar/selftests/nisar_reader.lua
@@ -21,16 +21,15 @@ f:close()
 
 -- Correct values test for different POIs
 
-local numPoints = 1  -- Set to 1 to use a specific fixed point
---local numPoints = 10000
-local height = 0
+local numPoints = 1000  -- Set to 1 to use a specific fixed point
 
-local lons, lats = {}, {}
+local lons, lats, heights = {}, {}, {}
 
 if numPoints == 1 then
     -- Use hardcoded test point
     lons = { -117.9705 }
     lats = {   34.8005 }
+    heights = { 0 }
 else
     -- Generate lon/lat arrays across the geographic extent
     -- Original extent
@@ -52,6 +51,7 @@ else
         local t = (i - 1) / (numPoints - 1)
         table.insert(lons, lonMin + t * (lonMax - lonMin))
         table.insert(lats, latMin + t * (latMax - latMin))
+        table.insert(heights, 0)
     end
 end
 
@@ -71,9 +71,12 @@ local nanCount = 0
 local totalCount = 0
 local failedSamples = 0
 
+local serialResults = {}
+
 for j = 1, numPoints do
     local lon = lons[j]
     local lat = lats[j]
+    local height = heights[j]
     local tbl, err = dem:sample(lon, lat, height)
 
     runner.assert(err == 0)
@@ -82,7 +85,10 @@ for j = 1, numPoints do
     if err ~= 0 then
         print(string.format("Point: %d, (%.5f, %.5f) ======> FAILED to read, err# %d", j, lon, lat, err))
         failedSamples = failedSamples + 1
+        table.insert(serialResults, nil)
     else
+        table.insert(serialResults, tbl)
+
         for k, v in ipairs(tbl) do
             local value = v["value"]
             local fname = v["file"]
@@ -91,7 +97,7 @@ for j = 1, numPoints do
                 nanCount = nanCount + 1
             end
             -- print(string.format("(%.5f, %.5f)  %8.4f", lon, lat, value))
-            print(string.format("(%.5f, %.5f)  %8.4f  %s\n", lon, lat, value, fname))
+            -- print(string.format("(%.5f, %.5f)  %8.4f  %s\n", lon, lat, value, fname))
         end
     end
 end
@@ -99,8 +105,64 @@ end
 local stoptime = time.latch()
 local dtime = stoptime-starttime
 local percentNaN = (nanCount / totalCount) * 100
-print(string.format("%d points, %d samples, ExecTime: %f, failed reads: %d, NaN Values: %d (%.2f%%)", numPoints, totalCount, dtime, failedSamples, nanCount, percentNaN))
+print(string.format("Serial sampling %d points, %d samples, ExecTime: %f, failed reads: %d, NaN Values: %d (%.2f%%)\n", numPoints, totalCount, dtime, failedSamples, nanCount, percentNaN))
 
+
+local batchResults = {}
+starttime = time.latch();
+tbl, err = dem:batchsample(lons, lats, heights)
+
+runner.assert(err == 0)
+runner.assert(tbl ~= nil)
+
+if err ~= 0 then
+    print(string.format("Point: %d, (%.5f, %.5f) ======> FAILED to read, err# %d", j, lon, lat, err))
+    failedSamples = failedSamples + 1
+    table.insert(batchResults, nil)
+else
+    batchResults = tbl
+end
+
+stoptime = time.latch()
+dtime = stoptime-starttime
+print(string.format("Batch sampling %d points, %d samples, ExecTime: %f\n", numPoints, totalCount, dtime))
+
+-- Compare serial and batch results
+print("\n------------------------------------\nComparing Serial and Batch Results\n------------------------------------")
+local totalMismatches = 0
+local totalFailedSerial = 0
+local totalFailedBatch = 0
+
+for i = 1, numPoints do
+    local serialSample = serialResults[i]
+    local batchSample = batchResults[i]
+
+    if (serialSample == nil and batchSample == nil) then
+        -- Both failed
+        totalFailedSerial = totalFailedSerial + 1
+        totalFailedBatch = totalFailedBatch + 1
+        print(string.format("Point %d: Both methods failed", i))
+    elseif (serialSample == nil) then
+        -- Serial failed
+        totalFailedSerial = totalFailedSerial + 1
+        totalMismatches = totalMismatches + 1
+        print(string.format("Point %d: Serial failed, Batch succeeded", i))
+    elseif (batchSample == nil) then
+        -- Batch failed
+        totalFailedBatch = totalFailedBatch + 1
+        totalMismatches = totalMismatches + 1
+        print(string.format("Point %d: Batch failed, Serial succeeded", i))
+    else
+        -- Compare values
+        for j, serialValue in ipairs(serialSample) do
+            local batchValue = batchSample[j]
+            if not batchValue or math.abs(serialValue["value"] - batchValue["value"]) > 1e-6 then
+                totalMismatches = totalMismatches + 1
+                print(string.format("Point %d, Sample %d: Serial %.6f != Batch %.6f", i, j, serialValue["value"], batchValue["value"]))
+            end
+        end
+    end
+end
 
 -- Report Results --
 runner.report()

--- a/datasets/nisar/selftests/nisar_reader.lua
+++ b/datasets/nisar/selftests/nisar_reader.lua
@@ -11,10 +11,8 @@ end
 runner.authenticate({"asf-cloud"})
 runner.log(core.DEBUG)
 
--- TODO: This index file is from landsat hls but for now it will trick the reader into thinking it is from NISAR
---       Create a small geojson file with a few hdf5 files which would look like what CMR would return for NISAR query
 local srcfile, dirpath = runner.srcscript()
-local geojsonfile = dirpath.."../../landsat/data/hls_trimmed.geojson"
+local geojsonfile = dirpath.."../data/nisar_fake.geojson"
 local f = io.open(geojsonfile, "r")
 runner.assert(f, "failed to open geojson file")
 if not f then return end
@@ -23,8 +21,8 @@ f:close()
 
 -- Correct values test for different POIs
 
-local lons = {-116.9985}
-local lats = {   0.0011}
+local lons = {-117.9705}
+local lats = {  34.8005}
 local height = 0
 
 local expElevation   = {-14.10, -4.28, -17.18}

--- a/datasets/nisar/selftests/nisar_reader.lua
+++ b/datasets/nisar/selftests/nisar_reader.lua
@@ -21,7 +21,8 @@ f:close()
 
 -- Correct values test for different POIs
 
-local numPoints = 10000  -- Set to 1 to use a specific fixed point
+local numPoints = 1  -- Set to 1 to use a specific fixed point
+--local numPoints = 10000
 local height = 0
 
 local lons, lats = {}, {}
@@ -90,7 +91,7 @@ for j = 1, numPoints do
                 nanCount = nanCount + 1
             end
             -- print(string.format("(%.5f, %.5f)  %8.4f", lon, lat, value))
-            -- print(string.format("(%.5f, %.5f)  %8.4f  %s", lon, lat, value, fname))
+            print(string.format("(%.5f, %.5f)  %8.4f  %s\n", lon, lat, value, fname))
         end
     end
 end

--- a/datasets/nisar/selftests/nisar_reader.lua
+++ b/datasets/nisar/selftests/nisar_reader.lua
@@ -1,0 +1,74 @@
+local runner = require("test_executive")
+
+-- Requirements --
+
+if (not sys.getcfg("in_cloud") and not runner.isglobal()) then
+    return runner.skip()
+end
+
+-- Setup --
+
+runner.authenticate({"asf-cloud"})
+runner.log(core.DEBUG)
+
+-- TODO: This index file is from landsat hls but for now it will trick the reader into thinking it is from NISAR
+--       Create a small geojson file with a few hdf5 files which would look like what CMR would return for NISAR query
+local srcfile, dirpath = runner.srcscript()
+local geojsonfile = dirpath.."../../landsat/data/hls_trimmed.geojson"
+local f = io.open(geojsonfile, "r")
+runner.assert(f, "failed to open geojson file")
+if not f then return end
+local contents = f:read("*all")
+f:close()
+
+-- Correct values test for different POIs
+
+local lons = {-116.9985}
+local lats = {   0.0011}
+local height = 0
+
+local expElevation   = {-14.10, -4.28, -17.18}
+local expUncertainty = {  2.58,  0.34,  1.32}
+local expContributor = { 63846, 24955, 45641}
+
+local elevation_tolerance = 50.0 -- BlueTopo is updated constantly; we just want to check that a valid elevation (within reason) can be sampled
+
+print(string.format("\n--------------------------------\nTest: NISAR L2 Correct Values\n--------------------------------"))
+local dem = geo.raster(geo.parms({ asset = "nisar-L2-geoff", algorithm = "NearestNeighbour", bands = {"azimuthOffset", "rangeOffset"}, catalog = contents, sort_by_index = true }))
+runner.assert(dem ~= nil, "failed to create nisar-L2 dataset", true)
+
+for j, lon in ipairs(lons) do
+    local lat = lats[j]
+    local tbl, err = dem:sample(lon, lat, height)
+--[[
+    runner.assert(err == 0)
+    runner.assert(tbl ~= nil)
+
+    if err ~= 0 then
+        print(string.format("Point: %d, (%.3f, %.3f) ======> FAILED to read, err# %d",j, lon, lat, err))
+    else
+        local el, fname
+        for k, v in ipairs(tbl) do
+            local band = v["band"]
+            local value = v["value"]
+            fname = v["file"]
+            print(string.format("(%6.2f, %6.2f)  Band: %11s %8.2f  %s", lon, lat, band, value, fname))
+
+            if band == "Elevation" then
+                runner.assert(math.abs(value - expElevation[j]) < elevation_tolerance, string.format("Point: %d, (%.3f, %.3f) ======> FAILED",j, lon, lat))
+            elseif band == "Uncertainty" then
+                runner.assert(math.abs(value - expUncertainty[j]) < elevation_tolerance, string.format("Point: %d, (%.3f, %.3f) ======> FAILED",j, lon, lat))
+            elseif band == "Contributor" then
+                runner.assert(value == expContributor[j], string.format("Point: %d, (%.3f, %.3f) ======> FAILED",j, lon, lat))
+            end
+        end
+        print("\n")
+    end
+--]]
+end
+
+-- Report Results --
+
+runner.report()
+
+

--- a/datasets/pgc/package/ArcticDemMosaicRaster.h
+++ b/datasets/pgc/package/ArcticDemMosaicRaster.h
@@ -66,10 +66,14 @@ class ArcticDemMosaicRaster: public GeoRaster
                   TimeLib::datetime2gps(2023, 01, 18, 20, 23, 42) / 1000,
                   1,                   /* elevationBandNum */
                   GdalRaster::NO_BAND, /* maskBandNum      */
+                  NULL,                /* overrideGeoTransform */
                   &overrideTargetCRS) {}
 
-        static OGRErr overrideTargetCRS(OGRSpatialReference& target)
-        { return target.importFromWkt(getArcticDemWkt2()); }
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL)
+        {
+            static_cast<void>(param);
+            return target.importFromWkt(getArcticDemWkt2());
+        }
 };
 
 #endif  /* __arcticdem_mosaic_raster__ */

--- a/datasets/pgc/package/ArcticDemStripsRaster.h
+++ b/datasets/pgc/package/ArcticDemStripsRaster.h
@@ -63,8 +63,11 @@ class ArcticDemStripsRaster: public PgcDemStripsRaster
         ArcticDemStripsRaster(lua_State* L, RequestFields* rqst_parms, const char* key):
           PgcDemStripsRaster(L, rqst_parms, key, "arcticdem", "/n", &overrideTargetCRS) {}
 
-        static OGRErr overrideTargetCRS(OGRSpatialReference& target)
-        { return target.importFromWkt(getArcticDemWkt2()); }
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL)
+        {
+            static_cast<void>(param);
+            return target.importFromWkt(getArcticDemWkt2());
+        }
 };
 
 #endif  /* __arcticdem_strips_raster__ */

--- a/datasets/pgc/package/PgcDemStripsRaster.cpp
+++ b/datasets/pgc/package/PgcDemStripsRaster.cpp
@@ -47,7 +47,7 @@ static const std::vector<const char*> dates = {"start_datetime", "end_datetime"}
  * Constructor
  *----------------------------------------------------------------------------*/
 PgcDemStripsRaster::PgcDemStripsRaster(lua_State *L, RequestFields* rqst_parms, const char* key, const char* dem_name, const char* geo_suffix, GdalRaster::overrideCRS_t cb):
-    GeoIndexedRaster(L, rqst_parms, key, cb),
+    GeoIndexedRaster(L, rqst_parms, key, NULL, cb),
     demName(dem_name),
     path2geocells(parms->asset.asset->getPath() + std::string(geo_suffix))
 {

--- a/datasets/pgc/package/RemaDemMosaicRaster.h
+++ b/datasets/pgc/package/RemaDemMosaicRaster.h
@@ -67,10 +67,14 @@ class RemaDemMosaicRaster: public GeoRaster
                   TimeLib::datetime2gps(2023, 02, 24, 18, 51, 44) / 1000,
                   1,                   /* elevationBandNum */
                   GdalRaster::NO_BAND, /* flagsBandNum     */
+                  NULL,                /* overrideGeoTransform */
                   &overrideTargetCRS) {}
 
-        static OGRErr overrideTargetCRS(OGRSpatialReference& target)
-        { return target.importFromWkt(getRemaWkt2()); }
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL)
+        {
+            static_cast<void>(param);
+            return target.importFromWkt(getRemaWkt2());
+        }
 };
 
 #endif  /* __remadem_mosaic_raster__ */

--- a/datasets/pgc/package/RemaDemStripsRaster.h
+++ b/datasets/pgc/package/RemaDemStripsRaster.h
@@ -67,8 +67,11 @@ class RemaDemStripsRaster: public PgcDemStripsRaster
         RemaDemStripsRaster(lua_State* L, RequestFields* rqst_parms, const char* key):
           PgcDemStripsRaster(L, rqst_parms, key, "rema", "/s", &overrideTargetCRS) {}
 
-        static OGRErr overrideTargetCRS(OGRSpatialReference& target)
-        { return target.importFromWkt(getRemaWkt2()); }
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL)
+        {
+            static_cast<void>(param);
+            return target.importFromWkt(getRemaWkt2());
+        }
 };
 
 #endif  /* __remadem_strips_raster__ */

--- a/datasets/usgs3dep/package/Usgs3dep1meterDemRaster.cpp
+++ b/datasets/usgs3dep/package/Usgs3dep1meterDemRaster.cpp
@@ -58,7 +58,7 @@ const char* Usgs3dep1meterDemRaster::URL_str = "https://prd-tnm.s3.amazonaws.com
  * Constructor
  *----------------------------------------------------------------------------*/
 Usgs3dep1meterDemRaster::Usgs3dep1meterDemRaster(lua_State* L, RequestFields* rqst_parms, const char* key):
- GeoIndexedRaster(L, rqst_parms, key, &overrideTargetCRS),
+ GeoIndexedRaster(L, rqst_parms, key, NULL, &overrideTargetCRS),
  filePath(parms->asset.asset->getPath()),
  indexFile("/vsimem/" + GdalRaster::getUUID() + ".geojson")
 {
@@ -152,8 +152,9 @@ bool Usgs3dep1meterDemRaster::findRasters(raster_finder_t* finder)
 /*----------------------------------------------------------------------------
  * overrideTargetCRS
  *----------------------------------------------------------------------------*/
-OGRErr Usgs3dep1meterDemRaster::overrideTargetCRS(OGRSpatialReference& target)
+OGRErr Usgs3dep1meterDemRaster::overrideTargetCRS(OGRSpatialReference& target, const void* param)
 {
+    static_cast<void>(param);
     OGRErr ogrerr   = OGRERR_FAILURE;
     int northFlag   = 0;
     const int utm   = target.GetUTMZone(&northFlag);

--- a/datasets/usgs3dep/package/Usgs3dep1meterDemRaster.h
+++ b/datasets/usgs3dep/package/Usgs3dep1meterDemRaster.h
@@ -73,7 +73,7 @@ class Usgs3dep1meterDemRaster: public GeoIndexedRaster
         void    getIndexFile     (const std::vector<point_info_t>* points, std::string& file) final;
         bool    findRasters      (raster_finder_t* finder) final;
 
-        static OGRErr overrideTargetCRS(OGRSpatialReference& target);
+        static OGRErr overrideTargetCRS(OGRSpatialReference& target, const void* param=NULL);
 
         /*--------------------------------------------------------------------
          * Data

--- a/packages/core/package/SystemConfig.cpp
+++ b/packages/core/package/SystemConfig.cpp
@@ -68,7 +68,7 @@ int SystemConfig::luaPopulate (lua_State* L)
         mlog(e.level(), "Error populating system configuration: %s", e.what());
         status = false;
     }
-    
+
     lua_pushboolean(L, status);
     return 1;
 }
@@ -129,6 +129,7 @@ SystemConfig::SystemConfig(void):
         {"authenticate_to_ornldaac",    &authenticateToORNLDAAC},
         {"authenticate_to_lpdaac",      &authenticateToLPDAAC},
         {"authenticate_to_podaac",      &authenticateToPODAAC},
+        {"authenticate_to_asf",         &authenticateToASF},
         {"register_as_service",         &registerAsService},
         {"asset_directory",             &assetDirectory},
         {"normal_mem_thresh",           &normalMemoryThreshold},
@@ -171,7 +172,7 @@ void SystemConfig::setIfProvided(FieldElement<string>& field, const char* env)
     const char* str = getenv(env); // NOLINT(concurrency-mt-unsafe)
     if(str) field = str;
 }
-        
+
 /******************************************************************************
  * FUNCTIONS
  ******************************************************************************/

--- a/packages/core/package/SystemConfig.h
+++ b/packages/core/package/SystemConfig.h
@@ -89,7 +89,7 @@ class SystemConfig: public FieldDictionary
         SystemConfig& operator=(const SystemConfig&) = delete;
         SystemConfig(SystemConfig&&) = delete;
         SystemConfig& operator=(SystemConfig&&) = delete;
-        
+
         /*--------------------------------------------------------------------
          * Data
          *--------------------------------------------------------------------*/
@@ -104,6 +104,7 @@ class SystemConfig: public FieldDictionary
         FieldElement<bool>              authenticateToORNLDAAC      {true};
         FieldElement<bool>              authenticateToLPDAAC        {true};
         FieldElement<bool>              authenticateToPODAAC        {true};
+        FieldElement<bool>              authenticateToASF           {true};
         FieldElement<bool>              registerAsService           {true};
         FieldElement<string>            assetDirectory              {"asset_directory.csv"};
         FieldElement<float>             normalMemoryThreshold       {1.0};
@@ -125,7 +126,7 @@ class SystemConfig: public FieldDictionary
         FieldElement<string>            containerRegistry           {"742127912612.dkr.ecr.us-west-2.amazonaws.com"};
 
     private:
- 
+
         /*--------------------------------------------------------------------
          * Methods
          *--------------------------------------------------------------------*/

--- a/packages/geo/package/GdalRaster.h
+++ b/packages/geo/package/GdalRaster.h
@@ -94,7 +94,14 @@ class GdalRaster
         *     Callback definition for overriding Spatial Reference System.
         *     NOTE: implementation must be thread-safe
         *--------------------------------------------------------------------*/
-        typedef OGRErr (*overrideCRS_t)(OGRSpatialReference& crs);
+        typedef OGRErr (*overrideCRS_t)(OGRSpatialReference& crs, const void* param);
+
+        /*--------------------------------------------------------------------
+        * overrideGeoTransform_t
+        *     Callback definition for overriding GeoTransform
+        *     NOTE: implementation must be thread-safe
+        *--------------------------------------------------------------------*/
+        typedef CPLErr (*overrideGeoTransform_t)(double* gtf, const void* param);
 
         /* import bbox_t into this namespace from GeoFields.h */
         using bbox_t=GeoFields::bbox_t;
@@ -106,7 +113,8 @@ class GdalRaster
                            GdalRaster     (const GeoFields* _parms, const std::string& _fileName,
                                            double _gpsTime, uint64_t _fileId,
                                            int _elevationBandNum, int _flagsBandNum,
-                                           overrideCRS_t cb, bbox_t* aoi_bbox_override=NULL);
+                                           overrideGeoTransform_t gtf_cb, overrideCRS_t crs_cb,
+                                           bbox_t* aoi_bbox_override=NULL);
 
         virtual           ~GdalRaster     (void);
         void               open           (void);
@@ -121,6 +129,7 @@ class GdalRaster
         uint32_t           getSSerror     (void) const { return ssError; }
         int                getElevationBandNum (void) const { return elevationBandNum; }
         int                getFLagsBandNum (void) const { return flagsBandNum; }
+        overrideGeoTransform_t getOverrideGeoTransform(void) const { return overrideGeoTransform; }
         overrideCRS_t      getOverrideCRS (void) const { return overrideCRS; }
         double             getGpsTime     (void) const { return gpsTime; }
         int                getBandNumber  (const std::string& bandName);
@@ -147,9 +156,10 @@ class GdalRaster
         uint64_t            fileId;   /* unique identifier of raster file used for downstream processing */
 
         OGRCoordinateTransformation* transf;
-        OGRSpatialReference sourceCRS;
-        OGRSpatialReference targetCRS;
-        overrideCRS_t       overrideCRS;
+        OGRSpatialReference    sourceCRS;
+        OGRSpatialReference    targetCRS;
+        overrideGeoTransform_t overrideGeoTransform;
+        overrideCRS_t          overrideCRS;
 
         std::string     fileName;
         GDALDataset    *dset;

--- a/packages/geo/package/GeoIndexedRaster.cpp
+++ b/packages/geo/package/GeoIndexedRaster.cpp
@@ -84,11 +84,12 @@ void GeoIndexedRaster::deinit (void)
 /*----------------------------------------------------------------------------
  * Constructor
  *----------------------------------------------------------------------------*/
-GeoIndexedRaster::GeoIndexedRaster(lua_State *L, RequestFields* rqst_parms, const char* key, GdalRaster::overrideCRS_t cb):
+GeoIndexedRaster::GeoIndexedRaster(lua_State *L, RequestFields* rqst_parms, const char* key, GdalRaster::overrideGeoTransform_t gtf_cb, GdalRaster::overrideCRS_t crs_cb):
     RasterObject    (L, rqst_parms, key),
     cache           (MAX_READER_THREADS),
     ssErrors        (SS_NO_ERRORS),
-    crscb           (cb),
+    gtfcb           (gtf_cb),
+    crscb           (crs_cb),
     bbox            {0, 0, 0, 0},
     rows            (0),
     cols            (0),

--- a/packages/geo/package/GeoIndexedRaster.h
+++ b/packages/geo/package/GeoIndexedRaster.h
@@ -216,7 +216,7 @@ class GeoIndexedRaster: public RasterObject
          * Methods
          *--------------------------------------------------------------------*/
 
-                         GeoIndexedRaster      (lua_State* L, RequestFields* _parms, const char* key, GdalRaster::overrideCRS_t cb=NULL);
+                         GeoIndexedRaster      (lua_State* L, RequestFields* _parms, const char* key, GdalRaster::overrideGeoTransform_t gtf_cb=NULL, GdalRaster::overrideCRS_t crs_cb=NULL);
         virtual uint32_t getBatchGroupSamples  (const rasters_group_t* rgroup, List<RasterSample*>* slist, uint32_t flags, uint32_t pointIndx);
         static  uint32_t getBatchGroupFlags    (const rasters_group_t* rgroup, uint32_t pointIndx);
 
@@ -281,6 +281,7 @@ class GeoIndexedRaster: public RasterObject
         List<reader_t*>           serialReaders;
         List<batch_reader_t*>     batchReaders;
         perf_stats_t              perfStats;
+        GdalRaster::overrideGeoTransform_t gtfcb;
         GdalRaster::overrideCRS_t crscb;
 
         std::string               indexFile;

--- a/packages/geo/package/GeoIndexedRasterBatch.cpp
+++ b/packages/geo/package/GeoIndexedRasterBatch.cpp
@@ -363,6 +363,7 @@ void* GeoIndexedRaster::batchReaderThread(void *param)
                                         ur->rinfo->fileId,
                                         ur->rinfo->elevationBandNum,
                                         ur->rinfo->flagsBandNum,
+                                        breader->obj->gtfcb,
                                         breader->obj->crscb,
                                         &breader->obj->bbox);
 

--- a/packages/geo/package/GeoIndexedRasterSerial.cpp
+++ b/packages/geo/package/GeoIndexedRasterSerial.cpp
@@ -450,6 +450,7 @@ void* GeoIndexedRaster::serialReaderThread(void *param)
                                                         raster->getGpsTime(),
                                                         raster->getElevationBandNum(),
                                                         raster->getFLagsBandNum(),
+                                                        raster->getOverrideGeoTransform(),
                                                         raster->getOverrideCRS());
 
                             entry->bandSubset.push_back(subset);
@@ -546,6 +547,7 @@ bool GeoIndexedRaster::updateSerialCache(uint32_t& rasters2sample, const GroupOr
                                               rinfo.fileId,
                                               rinfo.elevationBandNum,
                                               rinfo.flagsBandNum,
+                                              gtfcb,
                                               crscb,
                                               &bbox);
                 const bool status = cache.add(key, item);

--- a/packages/geo/package/GeoRaster.cpp
+++ b/packages/geo/package/GeoRaster.cpp
@@ -56,10 +56,10 @@ void GeoRaster::deinit (void)
 /*----------------------------------------------------------------------------
  * Constructor
  *----------------------------------------------------------------------------*/
-GeoRaster::GeoRaster(lua_State *L, RequestFields* rqst_parms, const char* key, const std::string& _fileName,
-                     double _gpsTime, int elevationBandNum, int flagsBandNum, GdalRaster::overrideCRS_t cb):
+GeoRaster::GeoRaster(lua_State *L, RequestFields* rqst_parms, const char* key, const std::string& _fileName, double _gpsTime,
+                     int elevationBandNum, int flagsBandNum, GdalRaster::overrideGeoTransform_t gtf_cb, GdalRaster::overrideCRS_t crs_cb):
     RasterObject(L, rqst_parms, key),
-    raster(parms, _fileName, _gpsTime, fileDict.add(_fileName, true), elevationBandNum, flagsBandNum, cb)
+    raster(parms, _fileName, _gpsTime, fileDict.add(_fileName, true), elevationBandNum, flagsBandNum, gtf_cb, crs_cb)
 {
     /* Add Lua Functions */
     LuaEngine::setAttrFunc(L, "dim", luaDimensions);
@@ -144,6 +144,7 @@ uint32_t GeoRaster::getSubsets(const MathLib::extent_t& extent, int64_t gps, Lis
                                              raster.getGpsTime(),
                                              raster.getElevationBandNum(),
                                              raster.getFLagsBandNum(),
+                                             raster.getOverrideGeoTransform(),
                                              raster.getOverrideCRS());
                 slist.add(subset);
 

--- a/packages/geo/package/GeoRaster.h
+++ b/packages/geo/package/GeoRaster.h
@@ -67,7 +67,9 @@ class GeoRaster: public RasterObject
         static void   deinit     (void);
 
                       GeoRaster  (lua_State* L, RequestFields* rqst_parms, const char* key, const std::string& _fileName, double _gpsTime,
-                                  int elevationBandNum=GdalRaster::NO_BAND, int flagsBandNum=GdalRaster::NO_BAND, GdalRaster::overrideCRS_t cb=NULL);
+                                  int elevationBandNum=GdalRaster::NO_BAND, int flagsBandNum=GdalRaster::NO_BAND,
+                                  GdalRaster::overrideGeoTransform_t gtf_cb=NULL, GdalRaster::overrideCRS_t crs_cb=NULL);
+
                      ~GeoRaster  (void) override;
         uint32_t      getSamples (const point_info_t& pinfo, sample_list_t& slist, void* param=NULL) final;
         uint32_t      getSubsets (const MathLib::extent_t&  extent, int64_t gps, List<RasterSubset*>& slist, void* param=NULL) final;

--- a/packages/geo/package/geo.cpp
+++ b/packages/geo/package/geo.cpp
@@ -238,6 +238,20 @@ static void configGDAL(void)
     {
         mlog(CRITICAL, "PROJ library network capabilities are DISABLED");
     }
+
+    /*
+     * If user enabled CURL_VERBOSE or CPL_DEBUG then enable GDAL error reporting
+     * so that GDAL/CURL messages are logged
+     */
+    const char* debug = CPLGetConfigOption("CPL_DEBUG", "");
+    const char* curl_verbose = CPLGetConfigOption("CPL_CURL_VERBOSE", "");
+
+    if ((strcmp(debug, "ON") == 0 || strcmp(curl_verbose, "YES") == 0))
+    {
+        #ifndef GDAL_ERROR_REPORTING
+        #define GDAL_ERROR_REPORTING
+        #endif
+    }
 }
 
 /*----------------------------------------------------------------------------

--- a/platforms/linux/SlideRule.cpp
+++ b/platforms/linux/SlideRule.cpp
@@ -115,6 +115,10 @@
 #include "gedtm.h"
 #endif
 
+#ifdef __nisar__
+#include "nisar.h"
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <dlfcn.h>
@@ -416,6 +420,10 @@ int main (int argc, char* argv[])
         initgedtm();
     #endif
 
+    #ifdef __nisar__
+        initnisar();
+    #endif
+
     /* Load Plugins */
     ldplugins();
 
@@ -495,6 +503,10 @@ int main (int argc, char* argv[])
 
     #ifdef __gedtm__
         deinitgedtm();
+    #endif
+
+    #ifdef __nisar__
+        deinitnisar();
     #endif
 
     #ifdef __streaming__

--- a/targets/slideruleearth-aws/asset_directory.csv
+++ b/targets/slideruleearth-aws/asset_directory.csv
@@ -39,3 +39,4 @@ sliderule-stage,            iam-role,       s3,         sliderule-public,       
 gedtm-30meter,              iam-role,       nil,        /vsis3/sliderule/data/GEDTM/legendtm_rf_30m_m_s_20000101_20231231_go_epsg.4326_v20250130.tif, nil, us-west-2, https://s3.us-west-2.amazonaws.com
 gedtm-std,                  iam-role,       nil,        /vsis3/sliderule/data/GEDTM/gendtm_rf_30m_std_s_20000101_20231231_go_epsg.4326_v20250209.tif, nil, us-west-2, https://s3.us-west-2.amazonaws.com
 gedtm-dfm,                  iam-role,       nil,        /vsis3/sliderule/data/GEDTM/dfme_edtm_m_30m_s_20000101_20221231_go_epsg.4326_v20241230.tif,   nil, us-west-2, https://s3.us-west-2.amazonaws.com
+nisar-L2-geoff,             asf-cloud,      nil,        /vsis3/sds-n-cumulus-prod-nisar-sample-data/,                           nil,                us-west-2,      https://s3.us-west-2.amazonaws.com

--- a/targets/slideruleearth-aws/asset_directory.csv
+++ b/targets/slideruleearth-aws/asset_directory.csv
@@ -39,4 +39,4 @@ sliderule-stage,            iam-role,       s3,         sliderule-public,       
 gedtm-30meter,              iam-role,       nil,        /vsis3/sliderule/data/GEDTM/legendtm_rf_30m_m_s_20000101_20231231_go_epsg.4326_v20250130.tif, nil, us-west-2, https://s3.us-west-2.amazonaws.com
 gedtm-std,                  iam-role,       nil,        /vsis3/sliderule/data/GEDTM/gendtm_rf_30m_std_s_20000101_20231231_go_epsg.4326_v20250209.tif, nil, us-west-2, https://s3.us-west-2.amazonaws.com
 gedtm-dfm,                  iam-role,       nil,        /vsis3/sliderule/data/GEDTM/dfme_edtm_m_30m_s_20000101_20221231_go_epsg.4326_v20241230.tif,   nil, us-west-2, https://s3.us-west-2.amazonaws.com
-nisar-L2-geoff,             asf-cloud,      nil,        /vsis3/sds-n-cumulus-prod-nisar-sample-data/,                           nil,                us-west-2,      https://s3.us-west-2.amazonaws.com
+nisar-L2-geoff,             asf-cloud,      nil,        /vsis3/sds-n-cumulus-prod-nisar-sample-data,                           nil,                us-west-2,      https://s3.us-west-2.amazonaws.com

--- a/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
+++ b/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
@@ -99,7 +99,7 @@ RUN git clone https://gitlab.dkrz.de/k202009/libaec.git && \
     ldconfig
 
     # install hdf5 (for gdal support)
-    # do not enable thread safety, GDAL does not need it and it is slower
+    # disable high-level library API and enable thread safety (we need it for Sliderule)
 RUN git clone https://github.com/HDFGroup/hdf5.git && \
     cd hdf5 && \
     HDF5_VERSION=`curl -s https://api.github.com/repos/HDFGroup/hdf5/releases/latest | jq '.tag_name' | tr -d "\""` && \
@@ -107,7 +107,7 @@ RUN git clone https://github.com/HDFGroup/hdf5.git && \
     HDF5_INSTALL_DIR=/usr/local/HDF_Group/HDF5/$HDF5_VERSION && \
     mkdir -p /build/hdf5 && \
     cd /build/hdf5 && \
-    cmake /hdf5 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DHDF5_BUILD_HL_LIB=ON -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_ENABLE_THREADSAFE=OFF -DCMAKE_INSTALL_PREFIX=$HDF5_INSTALL_DIR && \
+    cmake /hdf5 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DHDF5_BUILD_HL_LIB=OFF -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_ENABLE_THREADSAFE=ON -DCMAKE_INSTALL_PREFIX=$HDF5_INSTALL_DIR && \
     make -j8 && \
     make install && \
     echo "/usr/local/HDF_Group/HDF5/${HDF5_VERSION}/lib" > /etc/ld.so.conf.d/hdf5.conf && \

--- a/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
+++ b/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
@@ -86,6 +86,33 @@ RUN git clone https://github.com/libgeos/geos.git && \
     make install && \
     ldconfig
 
+    # install libaec (required by HDF5 for SZIP support)
+    # use known good version, there is no release tag to query programatically
+RUN git clone https://gitlab.dkrz.de/k202009/libaec.git && \
+    cd libaec && \
+    git checkout v1.0.6 && \
+    mkdir -p /build/libaec && \
+    cd /build/libaec && \
+    cmake /libaec -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON && \
+    make -j8 && \
+    make install && \
+    ldconfig
+
+    # install hdf5 (for gdal support)
+    # do not enable thread safety, GDAL does not need it and it is slower
+RUN git clone https://github.com/HDFGroup/hdf5.git && \
+    cd hdf5 && \
+    HDF5_VERSION=`curl -s https://api.github.com/repos/HDFGroup/hdf5/releases/latest | jq '.tag_name' | tr -d "\""` && \
+    git checkout $HDF5_VERSION && \
+    HDF5_INSTALL_DIR=/usr/local/HDF_Group/HDF5/$HDF5_VERSION && \
+    mkdir -p /build/hdf5 && \
+    cd /build/hdf5 && \
+    cmake /hdf5 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DHDF5_BUILD_HL_LIB=ON -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_ENABLE_THREADSAFE=OFF -DCMAKE_INSTALL_PREFIX=$HDF5_INSTALL_DIR && \
+    make -j8 && \
+    make install && \
+    echo "/usr/local/HDF_Group/HDF5/${HDF5_VERSION}/lib" > /etc/ld.so.conf.d/hdf5.conf && \
+    ldconfig
+
 # install gdal dependency
 RUN git clone https://github.com/OSGeo/gdal.git && \
     cd gdal && \
@@ -93,7 +120,13 @@ RUN git clone https://github.com/OSGeo/gdal.git && \
     git checkout $VERSION && \
     mkdir -p /build/gdal && \
     cd /build/gdal && \
-    cmake /gdal -DCMAKE_BUILD_TYPE=Release -DBUILD_APPS=OFF -DGDAL_USE_SWIG:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=OFF && \
+    cmake /gdal -DCMAKE_BUILD_TYPE=Release -DBUILD_APPS=OFF -DGDAL_USE_SWIG:BOOL=OFF -DBUILD_PYTHON_BINDINGS:BOOL=OFF \
+          -DGDAL_USE_HDF5=ON \
+          -DGDAL_ENABLE_HDF5_GLOBAL_LOCK=OFF \
+          -DHDF5_INCLUDE_DIR=$HDF5_INSTALL_DIR/include  \
+          -DHDF5_LIBRARY=$HDF5_INSTALL_DIR/lib/libhdf5.so \
+          -DHDF5_HL_LIBRARY=$HDF5_INSTALL_DIR/lib/libhdf5_hl.so \
+          -DCMAKE_PREFIX_PATH=$HDF5_INSTALL_DIR && \
     make -j8 && \
     make install && \
     ldconfig

--- a/targets/slideruleearth-aws/server.lua
+++ b/targets/slideruleearth-aws/server.lua
@@ -65,6 +65,10 @@ if sys.getcfg("authenticate_to_podaac") then
     local script_parms = {earthdata="https://archive.podaac.earthdata.nasa.gov/s3credentials", identity="podaac-cloud"}
     core.script("earth_data_auth", json.encode(script_parms)):global("PodaacAuthScript")
 end
+if sys.getcfg("authenticate_to_asf") then
+    local script_parms = {earthdata="https://nisar.asf.earthdatacloud.nasa.gov/s3credentials", identity="asf-cloud"}
+    core.script("earth_data_auth", json.encode(script_parms)):global("AsfAuthScript")
+end
 
 --------------------------------------------------
 -- Application Server


### PR DESCRIPTION
Initial implementation of NISAR L2 GOFF product support

This update includes minor modifications to the common raster code to support NISAR-specific handling. The Docker build file has been updated accordingly but has not yet been tested.

Note for development systems:
You must uninstall any existing GDAL libraries before proceeding. Then, build and install the following components in order:

libaec
libhdf5 (with thread safety enabled)
GDAL (with HDF5 support)

The Docker build file includes the correct cmake parameters for each of these libraries.

Even though GDAL itself is not thread-safe, HDF5 must be built with thread safety enabled. This is required in our applications, where each dataset is opened and read in a dedicated thread. If multiple datasets are accessed from the same HDF5 file without thread-safe support, crashes will occur.