### PR TITLE
Changed arrow SNAPPY compression to ZSTD

### DIFF
--- a/packages/arrow/package/ArrowDataFrame.cpp
+++ b/packages/arrow/package/ArrowDataFrame.cpp
@@ -639,7 +639,16 @@ int ArrowDataFrame::luaExport (lua_State* L)
 
                 // set writer properties
                 parquet::WriterProperties::Builder writer_props_builder;
-                writer_props_builder.compression(parquet::Compression::SNAPPY);
+
+                // ZSTD compression good compromize between speed (SNAPPY) and file size (GZIP)
+                writer_props_builder.compression(parquet::Compression::ZSTD);
+
+                // Improves compression and read/write efficiency by grouping more rows per chunk, default is 64k
+                writer_props_builder.max_row_group_length(500000);
+
+                // Enables dictionary encoding for repeated values (e.g. strings)
+                writer_props_builder.enable_dictionary();
+
                 writer_props_builder.version(parquet::ParquetVersion::PARQUET_2_6);
                 const shared_ptr<parquet::WriterProperties> writer_props = writer_props_builder.build();
 

--- a/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
+++ b/targets/slideruleearth-aws/docker/sliderule/Dockerfile.buildenv
@@ -45,7 +45,7 @@ RUN git clone https://github.com/apache/arrow.git && \
     git checkout apache-arrow-19.0.1 && \
     mkdir -p /build/arrow && \
     cd /build/arrow && \
-    cmake /arrow/cpp -DARROW_PARQUET=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_SNAPPY=ON -D ARROW_CSV=ON -DARROW_FILESYSTEM=ON && \
+    cmake /arrow/cpp -DARROW_PARQUET=ON -DARROW_WITH_ZSTD=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_SNAPPY=ON -DARROW_CSV=ON -DARROW_FILESYSTEM=ON && \
     make -j8 && \
     make install && \
     ldconfig

--- a/targets/slideruleearth-aws/docker/sliderule/Dockerfile.runtime
+++ b/targets/slideruleearth-aws/docker/sliderule/Dockerfile.runtime
@@ -20,6 +20,7 @@ RUN dnf update \
   openssl \
   libtiff \
   zlib \
+  libzstd-devel \
   gmp \
   libomp \
   && dnf clean all \


### PR DESCRIPTION
This change addresses [Issue #160](https://github.com/SlideRuleEarth/sliderule/issues/160) by replacing SNAPPY with ZSTD as the default Parquet compression codec. The goal is to reduce file size while maintaining fast write performance.

We also tuned the writer by:

Setting max_row_group_length = 500,000 (improves compression efficiency)
Enabling dictionary encoding (benefits ZSTD and GZIP, SNAPPY does not gain much)

To enable ZSTD support, arrow lib had to be rebuilt with -DARROW_WITH_ZSTD=ON and reinstalled.

Below is the performance comparison:
| Codec  | Write Time (s) | File Size (bytes) | Size Reduction vs SNAPPY | Time Increase vs SNAPPY |
|--------|----------------|-------------------|---------------------------|--------------------------|
| SNAPPY | 0.227106       | 10,461,869        | —                         | —                        |
| GZIP   | 1.022542       | 7,994,758         | **–23.6%**                | **+350%**                |
| ZSTD   | 0.231440       | 8,229,423         | **–21.3%**                | **+1.9%**                |
