### PR TITLE
Fix inert yapc.score photon filtering and fail loudly on unsupported YAPC configurations (fixes #648)

### DIFF
--- a/apps/node/datasets/icesat2/package/Atl03DataFrame.cpp
+++ b/apps/node/datasets/icesat2/package/Atl03DataFrame.cpp
@@ -539,6 +539,19 @@ void* Atl03DataFrame::subsettingThread (void* parm)
 
     try
     {
+        /* Check YAPC Configuration */
+        if(parms.stages[Icesat2Parameters::STAGE_YAPC])
+        {
+            if(parms.yapc.version.value != 0)
+            {
+                throw RunTimeException(CRITICAL, RTE_FAILURE, "yapc version %d is not supported by atl03x; only version 0 (scores read from the ATL03 granule) is supported", parms.yapc.version.value);
+            }
+            if(!df->useYapc006 && !df->useYapc007)
+            {
+                throw RunTimeException(CRITICAL, RTE_FAILURE, "yapc scores are not present in ATL03 granules prior to release 006 (granule release: %d)", parms.granuleFields.version.value);
+            }
+        }
+
         /* Start Reading ATL08 Data */
         Atl08Class atl08(df);
 
@@ -678,7 +691,7 @@ void* Atl03DataFrame::subsettingThread (void* parm)
             if(df->useYapc006) // read from atl03 granule release 006
             {
                 yapc_score = atl03.weight006_ph[current_photon];
-                if(yapc_score < parms.yapc.score)
+                if(yapc_score < parms.yapc.score.value)
                 {
                     continue;
                 }
@@ -686,7 +699,7 @@ void* Atl03DataFrame::subsettingThread (void* parm)
             else if(df->useYapc007) // read from atl03 granule release 007
             {
                 yapc_score = atl03.weight007_ph[current_photon];
-                if(yapc_score < parms.yapc.score)
+                if(yapc_score < parms.yapc.score.value)
                 {
                     continue;
                 }

--- a/apps/node/datasets/icesat2/package/Atl03Parameters.cpp
+++ b/apps/node/datasets/icesat2/package/Atl03Parameters.cpp
@@ -93,6 +93,12 @@ void YapcFields::fromLua (lua_State* L, int index)
     if(lua_istable(L, index))
     {
         FieldMap<Field>::fromLua(L, index);
+
+        if(version.value < 0 || version.value > 3)
+        {
+            throw RunTimeException(CRITICAL, RTE_FAILURE, "invalid yapc version: %d", version.value);
+        }
+
         provided = true;
     }
 }

--- a/apps/node/datasets/icesat2/package/Atl03Reader.cpp
+++ b/apps/node/datasets/icesat2/package/Atl03Reader.cpp
@@ -861,6 +861,10 @@ Atl03Reader::YapcScore::YapcScore (const info_t* info, const Region& region, con
     {
         throw RunTimeException(CRITICAL, RTE_FAILURE, "Invalid YAPC version specified: %d", info->reader->parms->yapc.version.value);
     }
+    else if(!atl03.read_yapc006 && !atl03.read_yapc007) // version 0, but no granule scores available
+    {
+        throw RunTimeException(CRITICAL, RTE_FAILURE, "YAPC scores are not present in ATL03 granules prior to release 006 (granule release: %d)", info->reader->parms->granuleFields.version.value);
+    }
 }
 
 /*----------------------------------------------------------------------------
@@ -1394,7 +1398,7 @@ void* Atl03Reader::subsettingThread (void* parm)
                         if(yapc.score) // dynamically calculated
                         {
                             yapc_score = yapc[current_photon];
-                            if(yapc_score < parms->yapc.score)
+                            if(yapc_score < parms->yapc.score.value)
                             {
                                 break;
                             }
@@ -1402,7 +1406,7 @@ void* Atl03Reader::subsettingThread (void* parm)
                         else if(atl03.read_yapc006) // read from atl03 granule release 006
                         {
                             yapc_score = atl03.weight006_ph[current_photon];
-                            if(yapc_score < parms->yapc.score)
+                            if(yapc_score < parms->yapc.score.value)
                             {
                                 break;
                             }
@@ -1410,7 +1414,7 @@ void* Atl03Reader::subsettingThread (void* parm)
                         else if(atl03.read_yapc007) // read from atl03 granule release 007
                         {
                             yapc_score = atl03.weight007_ph[current_photon];
-                            if(yapc_score < parms->yapc.score)
+                            if(yapc_score < parms->yapc.score.value)
                             {
                                 break;
                             }

--- a/apps/node/datasets/icesat2/selftests/atl03_dataframe.lua
+++ b/apps/node/datasets/icesat2/selftests/atl03_dataframe.lua
@@ -179,6 +179,73 @@ runner.unittest("ATL06 Surface Fitter", function()
 
 end, {"long"})
 
+-- Self Test --
+
+runner.unittest("ATL03 DataFrame - YAPC Score Filter", function()
+
+    local poly = {
+        { lon = -42.0, lat = 79.9 },
+        { lon = -40.0, lat = 79.9 },
+        { lon = -40.0, lat = 80.1 },
+        { lon = -42.0, lat = 80.1 },
+        { lon = -42.0, lat = 79.9 }
+    }
+
+    local function count_rows(score)
+        local parms = icesat2.parms03({
+            srt = 3,
+            cnf = -2,
+            poly = poly,
+            yapc = { version = 0, score = score },
+            resource = "ATL03_20200304065203_10470605_007_01.h5"
+        }, nil, "icesat2")
+        local atl03h5 = h5coro.object(asset_name, parms["resource"])
+        local df = icesat2.atl03x("gt1l", parms, atl03h5, nil, nil, core.EVENTQ)
+        runner.assert(df:waiton(240000), "timed out creating dataframe", true)
+        runner.assert(df:inerror() == false, "dataframe encountered error")
+        local min_score = 65535
+        for i = 1, math.min(df:numrows(), 1000) do
+            if df["yapc_score"][i] < min_score then
+                min_score = df["yapc_score"][i]
+            end
+        end
+        return df:numrows(), min_score
+    end
+
+    local rows_all, min_score_all = count_rows(0)
+    local rows_mid, min_score_mid = count_rows(1000)
+    local rows_high, min_score_high = count_rows(8000)
+
+    runner.assert(rows_all > 0, "no photons returned for score 0")
+    runner.assert(rows_mid <= rows_all, string.format("score 1000 did not filter photons: %d > %d", rows_mid, rows_all))
+    runner.assert(rows_high < rows_all, string.format("score 8000 did not filter photons: %d >= %d", rows_high, rows_all))
+    runner.assert(rows_high <= rows_mid, string.format("score threshold not monotonic: %d > %d", rows_high, rows_mid))
+    runner.assert(min_score_mid >= 1000, string.format("photon below score threshold returned: %d < 1000", min_score_mid))
+    runner.assert(min_score_high >= 8000, string.format("photon below score threshold returned: %d < 8000", min_score_high))
+    print(string.format("rows: %d (score 0, min %d), %d (score 1000, min %d), %d (score 8000, min %d)",
+        rows_all, min_score_all, rows_mid, min_score_mid, rows_high, min_score_high))
+
+end)
+
+-- Self Test --
+
+runner.unittest("ATL03 DataFrame - YAPC Unsupported Version", function()
+
+    local parms = icesat2.parms03({
+        srt = 3,
+        cnf = 4,
+        yapc = { version = 3, score = 0 },
+        resource = "ATL03_20200304065203_10470605_007_01.h5"
+    }, nil, "icesat2")
+
+    local atl03h5 = h5coro.object(asset_name, parms["resource"])
+    local df = icesat2.atl03x("gt1l", parms, atl03h5, nil, nil, core.EVENTQ)
+
+    runner.assert(df:waiton(30000), "timed out creating dataframe", true)
+    runner.assert(df:numrows() == 0, string.format("photons returned for unsupported yapc version: %d", df:numrows()))
+
+end)
+
 -- Report Results --
 
 runner.report()

--- a/apps/node/datasets/icesat2/selftests/parameters.lua
+++ b/apps/node/datasets/icesat2/selftests/parameters.lua
@@ -62,6 +62,18 @@ runner.unittest("ICESat-2 Fields", function()
 
 end)
 
+-- Self Test --
+
+runner.unittest("Invalid YAPC Version", function()
+
+    local parms = icesat2.parms03({
+        yapc = { version = 9 }
+    })
+
+    runner.assert(parms == false)
+
+end)
+
 -- Report Results --
 
 runner.report()

--- a/clients/python/tests/test_atl03x.py
+++ b/clients/python/tests/test_atl03x.py
@@ -7,6 +7,7 @@ from sliderule import sliderule, icesat2
 
 TESTDIR = Path(__file__).parent
 RESOURCES = ["ATL03_20181019065445_03150111_006_02.h5"]
+RESOURCES_007 = ["ATL03_20181019065445_03150111_007_01.h5"]
 AOI = [ { "lat": -80.75, "lon": -70.00 },
         { "lat": -81.00, "lon": -70.00 },
         { "lat": -81.00, "lon": -65.00 },
@@ -339,3 +340,26 @@ class TestAtl03x:
         assert "x_atc" in gdf.keys()
         assert "atl03_cnf" in gdf.keys()
         assert "geometry" in gdf.keys()
+
+    def test_yapc_score_filter(self, init):
+        base = { "track": 1,
+                 "cnf": -2,
+                 "srt": 3 }
+        gdf_all = sliderule.run("atl03x", {**base, "yapc": {"version": 0, "score": 0}}, AOI, RESOURCES_007)
+        gdf_mid = sliderule.run("atl03x", {**base, "yapc": {"version": 0, "score": 1000}}, AOI, RESOURCES_007)
+        gdf_high = sliderule.run("atl03x", {**base, "yapc": {"version": 0, "score": 8000}}, AOI, RESOURCES_007)
+        assert init
+        assert len(gdf_all) > 0
+        assert len(gdf_high) < len(gdf_all) # threshold filters photons
+        assert len(gdf_high) <= len(gdf_mid) <= len(gdf_all) # row counts monotonic in threshold
+        assert gdf_mid.yapc_score.min() >= 1000
+        assert gdf_high.yapc_score.min() >= 8000
+
+    def test_yapc_unsupported_version(self, init):
+        parms = { "track": 1,
+                  "cnf": 0,
+                  "srt": 3,
+                  "yapc": { "version": 3, "score": 0 } }
+        gdf = sliderule.run("atl03x", parms, AOI, RESOURCES_007)
+        assert init
+        assert len(gdf) == 0 # yapc versions 1-3 are rejected by atl03x

--- a/docs/rtd/source/user_guide/icesat2.md
+++ b/docs/rtd/source/user_guide/icesat2.md
@@ -46,7 +46,7 @@ The default resulting DataFrame from this endpoint contains the following column
 |landcover|ATL08 land cover flags||Optional: must enable `phoreal`|
 |snowcover|ATL08 snow cover flags||Optional: must enable `phoreal`|
 |atl08_class|ATL08 photon classification|0:noise, 1:ground, 2:canopy, 3:top of canopy, 4:unclassified|Optional: must enable `phoreal` or specify `atl08_class`|
-|yapc_score|YAPC photon weight|0-255, higher is denser|Optional: must enable `yapc`|
+|yapc_score|YAPC photon weight|higher is denser; 0-65535 for scores read from release 007 granules, 0-255 for release 006|Optional: must enable `yapc`|
 |atl24_class|ATL24 photon classification|0:unclassified, 40:bathymetry, 41:sea surface|Optional: must enable `atl24`|
 |atl24_confidence|ATL24 photon classification bathymetry confidence score|0 to 1.0, higher is more confident (float)|Optional: must enable `atl24`|
 |spot|ATLAS detector field of view|1-6|Independent of spacecraft orientation|
@@ -88,12 +88,12 @@ ATL03 contains a set of photon classification values, that are designed to ident
 The experimental YAPC (Yet Another Photon Classifier) photon-classification scheme assigns each photon a score based on the number of adjacent photons.  YAPC parameters are provided as a dictionary, with entries described below:
 
 * `yapc`: settings for the yapc algorithm; if provided then SlideRule will execute the YAPC classification on all photons
-    - `score`: the minimum yapc classification score of a photon to be used in the processing request
+    - `score`: the minimum yapc classification score of a photon to be used in the processing request; the score is compared against the raw score values, so its scale depends on where the scores come from: 0-65535 for scores read from release 007 granules (`weight_ph`, where 65535 represents the saturation density), 0-255 for scores read from release 006 granules and for scores calculated on the servers (versions 1-3)
     - `knn`: the number of nearest neighbors to use, or specify 0 to allow automatic selection of the number of neighbors (version 2 only)
     - `min_knn`: minimum number of k-nearest neighbors (version 3 only)
     - `win_h`: the window height used to filter the nearest neighbors (overrides calculated value if non-zero)
     - `win_x`: the window width used to filter the nearest neighbors
-    - `version`: the version of the YAPC algorithm to use; 0:read from ATL03 granule, 1-3:algorithm version (not supported by `atl03x`)
+    - `version`: the version of the YAPC algorithm to use; 0:read from ATL03 granule, 1-3:algorithm version (not supported by `atl03x`; requests to `atl03x` with versions 1-3 are rejected with an error)
 
 To run the YAPC algorithm, specify the YAPC settings as a sub-dictionary. Here is an example set of parameters that runs YAPC:
 
@@ -531,7 +531,7 @@ The GeoDataFrame for each photon extent has the following columns:
 - `atl08_class`: the photon's ATL08 classification (0: noise, 1: ground, 2: canopy, 3: top of canopy, 4: unclassified)
 - `atl03_cnf`: the photon's ATL03 confidence level (-2: TEP, -1: not considered, 0: background, 1: within 10m, 2: low, 3: medium, 4: high)
 - `quality_ph`: the photon's quality classification (0: nominal, 1: possible after pulse, 2: possible impulse responpse effect, 3: possible tep)
-- `yapc_score`: the photon's YAPC classification (0 - 255, the larger the number the higher the confidence in surface reflection)
+- `yapc_score`: the photon's YAPC classification (the larger the number the higher the confidence in surface reflection; 0 - 65535 for scores read from release 007 granules, 0 - 255 otherwise)
 
 Note: when PhoREAL is enabled, the ATL03 extent records (_atl03rec_) are enhanced to include the following populated fields:
 


### PR DESCRIPTION
### Root cause

The photon-selection threshold documented for `yapc.score` has been
silently inert on both atl03x and the legacy reader (#648). The filter
code exists and looks correct:

```cpp
if(yapc_score < parms.yapc.score)   // Atl03DataFrame.cpp (2 sites)
if(yapc_score < parms->yapc.score)  // Atl03Reader.cpp (3 sites)
```

but `score` is a `FieldElement<uint16_t>`, and `FieldElement` defines
`operator bool() const { return value != 0; }` and no `operator T()`.
Overload resolution therefore converts the *field object* to `bool`,
and the comparison is against 0 or 1 — never the requested threshold.
Any non-zero `score` behaves as "score >= 1", which explains every
symptom reported in #648:

- atl03x + `{version: 0, score: N}`: identical results for N = 0/150/
  1000/3300/8000, minimum returned `yapc_score` = 1 (weight-0 photons
  are typically already excluded by the default `quality_ph` filter);
- legacy atl06p + `{version: 3, score: N}`: selection changes once when
  any N > 0 is supplied (score-0 photons dropped) and is then
  insensitive to the value of N.

Additionally, `{version: 1..3}` on atl03x silently returned all-zero
scores (no v1-3 implementation exists in the dataframe path and nothing
rejected the request), and `{version: 0}` against pre-R006 granules
(no `weight_ph` dataset) silently returned zero scores on both paths.
With the comparison fixed, that last case would have become worse —
a non-zero threshold against all-zero scores silently returns an empty
result — so it now errors instead.

### What changed

- `Atl03DataFrame.cpp` / `Atl03Reader.cpp`: the five comparison sites
  use `parms.yapc.score.value` (the same pattern the neighboring ATL24
  confidence filter already uses).
- `Atl03DataFrame.cpp` (atl03x): requests with `yapc.version != 0` and
  requests with `version == 0` against pre-R006 granules now throw,
  which surfaces as a CRITICAL alert on the response stream instead of
  silent zero scores.
- `Atl03Reader.cpp` (legacy atl03s/sp, atl06/p): `YapcScore` now throws
  for `version == 0` against pre-R006 granules (v1-3 already threw for
  invalid versions).
- `Atl03Parameters.cpp`: `yapc.version` outside 0-3 is rejected at
  parameter parse time.
- `docs/rtd/source/user_guide/icesat2.md`: documents the score scale
  (below) and the loud rejection of v1-3 on atl03x.
- Tests (below).

### Semantics decision: v0 score scale

With `version: 0` the scores are the granule `weight_ph` values read
verbatim, and the threshold is compared against those raw values:
**0-65535** for R007 granules (DDA-03 saturation-normalized weights;
65535 = saturation density), **0-255** for R006. Server-computed v1-3
scores remain 0-255. I kept the raw-scale comparison rather than
normalizing because (a) the returned `yapc_score` column is the raw
value, so threshold and column stay directly comparable, (b) any
rescaling would silently change meaning again — the failure mode this
PR removes — and (c) the R007 scale is the product's own documented
scale (ATL03 ATBD R007 §5.2). The docs previously stated 0-255
unconditionally; they now state the scale per source. (Happy to switch
to a normalized comparison if you'd rather keep the documented 0-255
interface stable across releases — it's a two-line change on top of
this.)

### Tests

- `selftests/parameters.lua` (offline): invalid `yapc.version` rejected
  at parse.
- `selftests/atl03_dataframe.lua` (cloud): score threshold monotonically
  reduces row counts and enforces the minimum returned score on an R007
  granule already used by the repo's selftests
  (`ATL03_20200304065203_10470605_007_01.h5`); `{version: 3}` on atl03x
  returns an empty dataframe with an alert. Assertions are relational
  (monotonic counts, min-score bounds) rather than magic row counts, so
  they are robust to granule reprocessing. No existing expected values
  were touched.
- `clients/python/tests/test_atl03x.py` (live endpoint): the same two
  behaviors through the Python client, against the R007 twin of the
  existing test granule (`ATL03_20181019065445_03150111_007_01.h5`).

### Testing performed vs. deferred to CI

Honest status: I could not build the server locally (macOS box without
the buildenv container). What I did run:

- `clang++ -std=c++20 -fsyntax-only` over every modified C++ file plus
  `Icesat2Parameters.cpp`, `Atl06DispatchParameters.cpp`, and
  `SurfaceFitter.cpp` as consumers, against the repo headers (Linux
  `timer_t`/`UUID_STR_LEN`/`BUILDINFO` shimmed) — clean;
- `luac -p` on both modified selftests; `python -m py_compile` and
  codespell (repo pre-commit config) on the Python test and docs.

Not run: `make selftest` (needs a server build; the new
`parameters.lua` case is offline and will run there), the cloud
selftest, and the Python client tests (need a deployed build with this
change). I'd rely on your testrunner for those; the failure signatures
in #648 were verified empirically against the public v5.5.0 cluster,
and the new tests assert exactly the behaviors that were observed
broken.

### Possible follow-up (not in this PR)

Making `FieldElement::operator bool()` `explicit` would have turned all
five silent-conversion sites into compile errors and prevents
recurrence; I left it out to keep this diff minimal since I could not
compile the full tree to chase the fallout. Can open a separate issue
if useful.

Fixes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
